### PR TITLE
fix: Update "View on Github" link

### DIFF
--- a/src/features/about/about.tsx
+++ b/src/features/about/about.tsx
@@ -81,9 +81,10 @@ export const About = () => {
                     <div className="flex items-center gap-4">
                         <Button variant="outline" asChild>
                             <a
-                                href="https://github.com"
+                                href="https://github.com/Kieirra/murmure"
                                 target="_blank"
                                 rel="noopener noreferrer"
+                                aria-label="View the Murmure project on GitHub"
                             >
                                 <Github />
                                 <span>View on GitHub</span>


### PR DESCRIPTION
Simple proposal to update the link to the GitHub repository. 

<img width="311" height="140" alt="image" src="https://github.com/user-attachments/assets/8b9238c7-8497-48fa-b6ef-c76fc336110a" />
