### PR TITLE
feat: add custom target support for multi-format Linux packages

### DIFF
--- a/latest.json
+++ b/latest.json
@@ -7,6 +7,10 @@
             "signature": "",
             "url": "https://github.com/Kieirra/murmure/releases/download/1.2.1/murmure-x86_64.AppImage"
         },
+        "linux-deb-x86_64": {
+            "signature": "",
+            "url": "https://github.com/Kieirra/murmure/releases/download/1.2.1/murmure_1.2.1_amd64.deb"
+        },
         "windows-x86_64": {
             "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSQktXTTJjKzNtUEFSZkFrMlZlTGZmeCs5NTdkd0UvbXROMFNwbmxVa2hUQmJWdjdWRjRqOHo3NWxqL3U5NjErdFpuUURlTVVVQ3Z2aTQxb290RkltRm0vRGFJeFdIQ3dBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNzYwNjU0MzAzCWZpbGU6bXVybXVyZV8xLjIuMV94NjRfZW4tVVMubXNpCkRHb3lsWVIxNE13SExqN0Y5U2FBWWJyRlRISGJoaEtOc1N4QjBpSDMxWm90dlNDN0xrY3hybmRZZFlvUERpT2N6bkdIQnoreGNtWkhqdTNZNEJMbkJBPT0K",
             "url": "https://github.com/Kieirra/murmure/releases/download/1.2.1/murmure_1.2.1_x64_en-US.msi"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,6 +7,7 @@ use crate::shortcuts::{
 };
 use std::sync::Arc;
 use tauri::{AppHandle, Manager, State};
+use crate::LinuxFormatState;
 
 #[tauri::command]
 pub fn is_model_available(model: State<Arc<Model>>) -> bool {
@@ -144,4 +145,9 @@ pub fn set_overlay_position(app: AppHandle, position: String) -> Result<(), Stri
     let res = settings::save_settings(&app, &s);
     crate::overlay::update_overlay_position(&app);
     res
+}
+
+#[tauri::command]
+pub fn get_linux_format(state: State<LinuxFormatState>) -> String {
+    state.format.to_target_string()
 }

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,0 +1,84 @@
+use std::env;
+
+/// Represents the Linux installation format
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LinuxFormat {
+    /// AppImage format (default for generic Linux)
+    AppImage,
+    /// Debian package format (.deb)
+    Deb,
+}
+
+impl LinuxFormat {
+    /// Determine the Linux format based on environment or build configuration
+    pub fn detect() -> Self {
+        // Check environment variable first (useful for testing and CI/CD)
+        if let Ok(format) = env::var("MURMURE_LINUX_FORMAT") {
+            match format.to_lowercase().as_str() {
+                "deb" => return LinuxFormat::Deb,
+                "appimage" => return LinuxFormat::AppImage,
+                _ => {}
+            }
+        }
+
+        // Check if running on a Debian-based system and was installed via deb
+        #[cfg(target_os = "linux")]
+        {
+            // Check if the app was installed via dpkg (typical for .deb installations)
+            if Self::is_deb_installed() {
+                return LinuxFormat::Deb;
+            }
+        }
+
+        // Default to AppImage
+        LinuxFormat::AppImage
+    }
+
+    /// Check if the application was installed via Debian package manager
+    #[cfg(target_os = "linux")]
+    #[allow(dead_code)]
+    fn is_deb_installed() -> bool {
+        // Check if the executable path contains /opt/ or /usr/ (typical deb installation paths)
+        if let Ok(exe_path) = env::current_exe() {
+            let path_str = exe_path.to_string_lossy();
+            if path_str.contains("/opt/") || path_str.contains("/usr/") {
+                return true;
+            }
+        }
+
+        // Alternative: check if installed via apt/dpkg
+        // This is more reliable but requires system calls
+        std::process::Command::new("dpkg")
+            .args(&["-l", "murmure"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[allow(dead_code)]
+    fn is_deb_installed() -> bool {
+        false
+    }
+
+    /// Get the custom target string for the updater plugin
+    pub fn to_target_string(&self) -> String {
+        match self {
+            LinuxFormat::AppImage => "linux-x86_64".to_string(),
+            LinuxFormat::Deb => "linux-deb-x86_64".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_linux_format_to_target_string() {
+        assert_eq!(LinuxFormat::AppImage.to_target_string(), "linux-x86_64");
+        assert_eq!(LinuxFormat::Deb.to_target_string(), "linux-deb-x86_64");
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,6 +40,14 @@
                     "/usr/share/README.md": "../README.md",
                     "/usr/resources": "../resources/"
                 }
+            },
+            "deb": {
+                "files": {
+                    "/usr/share/doc/murmure/README.md": "../README.md",
+                    "/usr/share/murmure/resources": "../resources/"
+                },
+                "depends": [],
+                "desktopTemplate": null
             }
         }
     },


### PR DESCRIPTION
# Related to : https://github.com/Kieirra/murmure/issues/5

### Description
This pull request introduces **custom Linux target support** for the Tauri updater plugin, allowing **Murmure** to automatically deliver the correct package format (`.AppImage` or `.deb`) to users depending on their installation type.

It removes the ambiguity caused by Tauri’s generic `linux-x86_64` target and replaces it with a smart detection system that dynamically identifies the current platform format.

⚠️ **Note:** This implementation was developed and tested primarily on **Windows + WSL2**, with environment variables manually defined. It still requires **testing under real Linux installation conditions** (AppImage and .deb installations on actual distributions) to confirm behavior consistency.

---

### Problem Statement
Until now, the updater plugin recognized only generic Linux identifiers like `linux-x86_64`. This led to incorrect update delivery:
- Debian users received **AppImage updates**
- No clear way to distinguish or serve updates per Linux packaging type

This PR fixes these issues by implementing **automatic detection**, **custom targets**, and **per-format handling** within both backend and frontend layers.

---

### Solution Overview

#### 1. **Automatic Format Detection (Rust Backend)**
A new Rust module `updater.rs` was created to detect the installation format at runtime.

**Detection Strategy (priority order):**
1. Check for executable paths in `/opt/` or `/usr/` → typical for Debian installs
2. Attempt `dpkg -l murmure` → confirms Debian installation
3. Fallback: assume AppImage (default case)

This detection runs once at startup, stores the result in app state, and exposes it to the frontend.

#### 2. **State Management**
- Introduced `LinuxFormatState` struct stored in Tauri’s managed state.
- Detected once at launch and cached.
- Exposed to frontend via a new Tauri command `get_linux_format()`.

#### 3. **Frontend Integration (TypeScript/React)**
- The `UpdateChecker` component now queries `get_linux_format()` on mount.
- The returned value is passed as a custom `target` parameter to the updater plugin’s `check()` function.
- Graceful degradation on unsupported (non-linux) platforms (Windows/macOS): updater still works using default behavior.

#### 4. **Update Manifest (`latest.json`)**
Manifest structure extended with two explicit Linux targets:
```json
{
  "platforms": {
    "linux-x86_64": { "url": "https://.../murmure.AppImage" },
    "linux-deb-x86_64": { "url": "https://.../murmure.deb" }
  }
}
```
The plugin dynamically selects the correct target depending on the detected format.

#### 5. **Build Configuration (`tauri.conf.json`)**
- Added Debian bundling configuration with explicit install paths:
  - Binary → `/usr/bin/murmure`
  - Resources → `/usr/share/murmure/resources`
  - Documentation → `/usr/share/doc/murmure/`

---

### Architecture Flow
```text
App Startup
    ↓
LinuxFormat::detect() → Env var / system path / dpkg check
    ↓
LinuxFormatState { format } → Stored in Tauri state
    ↓
Frontend mounts UpdateChecker
    ↓
invoke('get_linux_format') → returns "linux-x86_64" or "linux-deb-x86_64"
    ↓
check({ target }) → passed to updater plugin
    ↓
Plugin resolves correct download from latest.json
```

---

### Files Changed
| File | Description |
|------|--------------|
| `src-tauri/src/updater.rs` | **NEW:** detection logic for Linux formats |
| `src-tauri/src/lib.rs` | initializes detection and stores state |
| `src-tauri/src/commands.rs` | adds `get_linux_format()` Tauri command |
| `src/features/update-checker/update-checker.tsx` | integrates target handling in updater call |
| `src-tauri/tauri.conf.json` | adds Debian bundling configuration |
| `latest.json` | introduces `linux-deb-x86_64` entry |

---

### Testing Procedures
#### Local Testing (WSL2)
```bash
# AppImage mode (default)
MURMURE_LINUX_FORMAT=appimage cargo tauri dev

# Debian mode
MURMURE_LINUX_FORMAT=deb cargo tauri dev
```
**Expected behavior:**
- AppImage mode → plugin fetches from `platforms["linux-x86_64"]`
- Debian mode → plugin fetches from `platforms["linux-deb-x86_64"]`

#### ⚙️ Windows/macOS
```bash
cargo tauri dev
```
**Expected behavior:**
- `get_linux_format()` gracefully fails (not supported)
- No crash / update flow unaffected

#### Next Steps
- Confirm runtime detection works correctly on native Linux installs
- Validate dpkg-based detection under Debian/Ubuntu
- Ensure manifest matching behavior in release builds

---

###  Benefits
 **User Experience**  
- Automatically gets the correct package format  
- No manual config or confusion  
- Unified update process for all Linux users  

 **Maintainability**  
- Easily extensible to future formats (Flatpak, Snap, RPM)  
- Environment override for CI  
- Modular design: detection ↔ usage separated  

 **Compatibility**  
- Works cross-platform with graceful fallback  
- Backward compatible (no breaking changes)  
- Non-intrusive integration with Tauri Updater  

 **Security**  
- Independent signature validation per format  
- Safer update URLs  
- Avoids mixing incompatible binaries  

---

### Future Improvements
- Add `linux-flatpak-x86_64`, `linux-snap-x86_64`, and `.rpm` support
- Support for `aarch64` (ARM64) builds
- Add auto-detection for Flatpak installs via `/var/lib/flatpak`

---

### Deployment Notes
When releasing a new version:
1. Build both `.AppImage` and `.deb` packages.
2. Upload both assets to GitHub releases.
3. Update `latest.json` manifest accordingly.
4. Users automatically receive updates matching their installation format.

---

### Conclusion
This PR significantly improves the **update experience for Linux users**, adding a smarter and more reliable delivery system for each platform type. Once validated on real Linux environments, this will make Murmure’s update flow fully production-ready across ecosystems.