### PR TITLE
Add Clear History Button to Transcription Module

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -29,6 +29,11 @@ pub fn get_recent_transcriptions(app: AppHandle) -> Result<Vec<HistoryEntry>, St
 }
 
 #[tauri::command]
+pub fn clear_history(app: AppHandle) -> Result<(), String> {
+    history::clear_history(&app).map_err(|e| format!("{:#}", e))
+}
+
+#[tauri::command]
 pub fn get_record_shortcut(app: AppHandle) -> Result<String, String> {
     let s = settings::load_settings(&app);
     Ok(s.record_shortcut)

--- a/src-tauri/src/history.rs
+++ b/src-tauri/src/history.rs
@@ -89,3 +89,12 @@ pub fn get_last_transcription(app: &AppHandle) -> Result<String> {
     let data = read_history(app)?;
     Ok(data.entries.first().unwrap().text.clone())
 }
+
+/// Clears all transcription history entries and emits an event to notify the frontend.
+pub fn clear_history(app: &AppHandle) -> Result<()> {
+    let mut data = read_history(app)?;
+    data.entries.clear();
+    write_history(app, &data)?;
+    let _ = app.emit("history-updated", ());
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,6 +99,7 @@ pub fn run() {
             is_model_available,
             get_model_path,
             get_recent_transcriptions,
+            clear_history,
             get_record_shortcut,
             set_record_shortcut,
             set_dictionary,

--- a/src/features/home/history/history.tsx
+++ b/src/features/home/history/history.tsx
@@ -1,4 +1,15 @@
+import { useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { Typography } from '@/components/typography';
+import { Button } from '@/components/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/dialog';
 import { toast } from 'sonner';
 import { formatTime } from './history.helpers';
 import { useHistoryState } from './hooks/use-history-state';
@@ -7,16 +18,50 @@ interface HistoryProps {}
 
 export const History = ({}: HistoryProps) => {
     const { history } = useHistoryState();
+    const [showClearDialog, setShowClearDialog] = useState(false);
+    const [isClearing, setIsClearing] = useState(false);
+
+    const handleClearHistory = async () => {
+        setIsClearing(true);
+        try {
+            await invoke('clear_history');
+            toast.success('History cleared', {
+                duration: 1500,
+                closeButton: true,
+            });
+            setShowClearDialog(false);
+        } catch (error) {
+            toast.error('Failed to clear history', {
+                duration: 2000,
+                closeButton: true,
+            });
+            console.error('Clear history error:', error);
+        } finally {
+            setIsClearing(false);
+        }
+    };
 
     return (
         <div className="space-y-2 w-full">
-            <Typography.Title>
-                Recent activity{' '}
-                <span className="text-[10px] text-zinc-400">
-                    (Only the last 5 transcriptions are kept; older text and
-                    audio files are deleted)
-                </span>
-            </Typography.Title>
+            <div className="flex items-center justify-between">
+                <Typography.Title>
+                    Recent activity{' '}
+                    <span className="text-[10px] text-zinc-400">
+                        (Only the last 5 transcriptions are kept; older text and
+                        audio files are deleted)
+                    </span>
+                </Typography.Title>
+                {history.length > 0 && (
+                    <Button
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => setShowClearDialog(true)}
+                        disabled={isClearing}
+                    >
+                        Clear
+                    </Button>
+                )}
+            </div>
             {history.length === 0 ? (
                 <Typography.Paragraph>
                     No transcriptions yet
@@ -61,6 +106,33 @@ export const History = ({}: HistoryProps) => {
                     ))}
                 </div>
             )}
+
+            <Dialog open={showClearDialog} onOpenChange={setShowClearDialog}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Clear History</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to clear all transcription history? This action cannot be undone.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setShowClearDialog(false)}
+                            disabled={isClearing}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={handleClearHistory}
+                            disabled={isClearing}
+                        >
+                            {isClearing ? 'Clearing...' : 'Clear'}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 };


### PR DESCRIPTION
## Summary
This pull request adds a **Clear History** button to the transcription interface, allowing users to delete all saved transcriptions at once. It provides a user-friendly way to manage stored data directly from the frontend while ensuring consistency and state synchronization with the backend.

---

## Implementation Details

### Backend (Rust)
- **New Function:** `clear_history()` implemented in `history.rs` to wipe the stored transcription history.
- **Command Exposure:** Added `clear_history` as a new Tauri command in `commands.rs` and registered it in `lib.rs`.

### Frontend (TypeScript/React)
- Added a **Clear** button in the `History` component.
- The button is **only visible** when transcription history is not empty.
- Added a **confirmation dialog** to prevent accidental deletions.
- On success or error, the app displays **toast notifications** to inform the user of the result.
- Emits a `history-updated` event to trigger state refresh and update the frontend.

---

## Benefits
- Simplifies history management for users.
- Improves UX with immediate feedback and confirmation prompts.
- Maintains synchronization between backend state and UI in real-time.

---

## Next Steps
- Add unit tests for `clear_history()` function.
- Confirm consistent behavior across Windows, macOS, and Linux.
- Consider adding granular deletion (single-item removal) in future updates.