### PR TITLE
docs(README): add a note on ALSA and Pipewire compatibility for Linux install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ The Windows build is self-signed, as I'm not paying certification authorities ju
 2. Make it executable: `chmod +x murmure-x86_64.AppImage`
 3. Run the AppImage.
 
+Murmure uses the [ALSA](https://www.alsa-project.org/wiki/Main_Page) API to
+access your microphone, so if you're running Pipewire for your audio stack,
+make sure that the ALSA API calls are routed through it (e.g. by installing
+[the `pipewire-alsa`
+package](https://archlinux.org/packages/extra/x86_64/pipewire-alsa/) on Arch
+Linux), otherwise you'll have errors such as `ALSA lib
+pcm_dsnoop.c:567:(snd_pcm_dsnoop_open) unable to open slave`.
+
 ## Usage
 
 Murmure provides a clean and focused speech-to-text experience.


### PR DESCRIPTION
When I started testing Murmure, it was unable to use my microphone for the recording. This is the first app I use to ever have had this issue so far.

Looking into it, it turns out that the lib used here (https://github.com/RustAudio/cpal) uses the ALSA API directly, and that to get it to work, people running [Pipewire](https://www.pipewire.org/) need to make sure that the ALSA API calls are routed to it.

On Arch Linux, I had to install `pipewire-alsa` for that.

Given Murmure seems to be in an unusual case (all apps such as browsers & co work fine without `pipewire-alsa` on my workstation), I figured a note in the install section wouldn't hurt so here it is!
