### PR TITLE
chore(pkg): set version `1.3.0` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "murmure",
     "private": true,
-    "version": "1.0.0",
+    "version": "1.3.0",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
When building the app, the following is printed:

```
$ pnpm tauri build

> murmure@1.0.0 tauri /<...>/murmure
> tauri build

        Info Looking up installed tauri packages to check mismatched versions...
     Running beforeBuildCommand `pnpm build`

> murmure@1.0.0 build /<...>/murmure
> tsc && vite build

[...]
```

Seeing the `1.0.0` was a bit weird given the app is in its `1.3.0` version.

This is due to the version specified in the `package.json`, even if
`src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml` are up-to-date and
include `1.3.0`

This PR fixes this (admittedly super minor)
