### PR TITLE
docs(contributing): add list of edits to be done when releasing a new version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,4 +89,13 @@ Components should be pure and keep markup simple; move logic to custom hooks or 
 3. Commit your changes (`git commit -m "Add new feature"`)
 4. Push and open a pull request
 
+## Releasing
 
+When releasing a new version of Murmure:
+
+1. Bump version number in <./src-tauri/Cargo.toml>
+2. Rebuild to make sure version number gets updated in <./src-tauri/Cargo.lock>
+3. Bump version number in <./package.json>
+4. Bump version number in <./src-tauri/tauri.conf.json>
+5. Use Tauri updater to bump version number and file signature in <./latest.json>
+6. Add new version overview to the Changelog section in the <./README.md>


### PR DESCRIPTION
In order to avoid #20 in the future :)

I loosely based this on 5e07337a1d5155e3a5cedc6cc8e28e5824bcbe9e

I'm pretty sure not everything has to be manually updated, and that I'll learn something about the Tauri updater along the way - I'd actually be happy to add details to step 4. or squash some of the previous steps into it!

Also, I'm aware that @Kieirra you're the only one to release Murmure so I'd understand if you'd consider this as unnecessary or overstepping in any way, and closed this right away consequently
