### PR TITLE
fix: correct overlay positioning with fractional scaling

### DIFF
--- a/src-tauri/src/overlay/overlay.rs
+++ b/src-tauri/src/overlay/overlay.rs
@@ -54,9 +54,6 @@ fn calculate_overlay_geometry(app_handle: &AppHandle) -> Option<(f64, f64, f64, 
         let monitor_size = monitor.size();
         let monitor_pos = monitor.position();
         let scale = monitor.scale_factor();
-
-        // Convert physical monitor dimensions to logical coordinates
-        // This is essential for multi-monitor setups with different scale factors
         let work_w = monitor_size.width as f64 / scale;
         let work_h = monitor_size.height as f64 / scale;
         let work_x = monitor_pos.x as f64 / scale;
@@ -65,7 +62,6 @@ fn calculate_overlay_geometry(app_handle: &AppHandle) -> Option<(f64, f64, f64, 
         let overlay_w = OVERLAY_BASE_WIDTH;
         let overlay_h = OVERLAY_BASE_HEIGHT;
 
-        // Center horizontally in logical coordinates
         let x = work_x + (work_w - overlay_w) / 2.0;
         let s = settings::load_settings(app_handle);
         let y = match s.overlay_position.as_str() {


### PR DESCRIPTION
## Summary
- Changed from using `work_area()` to `monitor.size()` and `monitor.position()` to properly handle fractional scaling (125%, 150%, etc.)