### PR TITLE
Replace rdev with native CGEventTap for macOS keyboard shortcuts

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,10 +56,9 @@ tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 parking_lot = "0.12"
 
-# rdev is used for keyboard event capture on Linux and macOS
-# Using fufesou fork which fixes macOS crash issues with rdev 0.5
-# Note: official rdev 0.5 crashes on macOS (see https://github.com/tauri-apps/tauri/discussions/7839)
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+# rdev is used for keyboard event capture on Linux only
+# macOS uses native CGEventTap (Quartz) instead for better reliability
+[target.'cfg(target_os = "linux")'.dependencies]
 rdev = { git = "https://github.com/fufesou/rdev" }
 
 # Core Foundation for macOS keyboard layout handling (AZERTY/QWERTY conversion)


### PR DESCRIPTION
## Summary
Replaces the rdev library with native Core Graphics `CGEventTap` (Quartz) for macOS keyboard event capture. This eliminates the dependency on the fufesou fork of rdev and uses the same low-level approach as Discord and OBS Studio for more reliable keyboard event handling.

## Key Changes

- **Removed rdev dependency** from macOS target in `Cargo.toml` (now Linux-only)
- **Implemented native CGEventTap** with full FFI bindings to Core Graphics and CoreFoundation frameworks
- **Added event tap callback** (`event_tap_callback`) that handles:
  - Key down/up events via `CGEventType`
  - Modifier key state tracking using NX device-specific flags for accurate left/right distinction
  - Automatic tap re-enabling after timeout
- **Refactored event processing** into two dedicated threads:
  - Thread 1: CGEventTap listener running on its own CFRunLoop
  - Thread 2: Event processor receiving keycodes via mpsc channel
- **Improved modifier key handling** with `convert_modifier()` function using NX device masks (e.g., `NX_DEVICELSHIFTKEYMASK`) for precise left/right key tracking
- **Maintained keyboard layout support** with existing `keycode_to_char()` and `char_to_vk()` functions for AZERTY/QWERTY conversion
- **Added comprehensive FFI definitions** for CGEventTap, CFRunLoop, and related Core Graphics/CoreFoundation APIs

## Implementation Details

- Uses `K_CG_EVENT_TAP_OPTION_LISTEN_ONLY` to passively observe events without consuming them
- Stores tap port in static `TAP_PORT` for re-enabling after timeout events
- Properly handles memory management with `Box::into_raw()` for the sender pointer passed to the callback
- Maintains backward compatibility with existing shortcut matching logic
- Accessibility permissions check remains unchanged

https://claude.ai/code/session_01Msh1CBUCDA32A1XKZRJwX5