### PR TITLE
feat: add native Wayland support for GNOME sessions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -146,6 +146,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "zbus",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a3c86f3fd70c0ffa500ed189abfa90b5a52398a45d5dc372fcc38ebeb7a645"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,15 +1404,19 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71c6c56e50f7acae2906a0dcbb34529ca647e40421119ad5d12e7f8ba6e50010"
 dependencies = [
+ "ashpd 0.12.3",
  "core-foundation 0.10.1",
  "core-graphics 0.25.0",
  "foreign-types-shared 0.3.1",
+ "futures",
  "libc",
  "log",
  "nom",
  "objc2 0.6.3",
  "objc2-app-kit",
  "objc2-foundation 0.3.2",
+ "reis",
+ "tokio",
  "windows 0.61.3",
  "x11rb",
  "xkbcommon",
@@ -1700,12 +1738,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1773,6 +1827,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2994,6 +3049,7 @@ name = "murmure"
 version = "1.7.0"
 dependencies = [
  "anyhow",
+ "ashpd 0.11.1",
  "axum",
  "chrono",
  "core-foundation 0.10.1",
@@ -4485,6 +4541,15 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "reis"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00939c5c526a1b4054ef8d9d96b3f92227f08ca355965e986741b556eda6d289"
+dependencies = [
+ "rustix 0.38.44",
+]
 
 [[package]]
 name = "rend"
@@ -6204,6 +6269,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -7750,6 +7816,7 @@ dependencies = [
  "ordered-stream",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",
@@ -7923,6 +7990,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 0.7.14",
  "zvariant_derive",
  "zvariant_utils",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,6 +66,11 @@ parking_lot = "0.12"
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 rdev = { git = "https://github.com/fufesou/rdev" }
 
+# Wayland support on Linux: ashpd for GlobalShortcuts portal, enigo with libei for input emulation
+[target.'cfg(target_os = "linux")'.dependencies]
+ashpd = "0.11"
+enigo = { version = "0.6", features = ["libei_tokio"] }
+
 # Core Foundation for macOS keyboard layout handling (AZERTY/QWERTY conversion)
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"

--- a/src-tauri/src/audio/audio.rs
+++ b/src-tauri/src/audio/audio.rs
@@ -202,10 +202,23 @@ pub fn write_transcription(app: &AppHandle, transcription: &str) -> Result<()> {
     if trigger == RecordingTrigger::WakeWord && mode != RecordingMode::Command {
         let settings = crate::settings::load_settings(app);
         if settings.auto_enter_after_wake_word {
-            if let Err(e) = simulate_enter_key() {
-                error!("Failed to simulate Enter key: {}", e);
-            } else {
-                debug!("Auto-enter: Enter key simulated after wake word transcription");
+            #[cfg(target_os = "linux")]
+            {
+                if crate::utils::wayland::is_wayland_session() {
+                    debug!("Auto-enter disabled on Wayland");
+                } else if let Err(e) = simulate_enter_key() {
+                    error!("Failed to simulate Enter key: {}", e);
+                } else {
+                    debug!("Auto-enter: Enter key simulated after wake word transcription");
+                }
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                if let Err(e) = simulate_enter_key() {
+                    error!("Failed to simulate Enter key: {}", e);
+                } else {
+                    debug!("Auto-enter: Enter key simulated after wake word transcription");
+                }
             }
         }
     }

--- a/src-tauri/src/clipboard/clipboard.rs
+++ b/src-tauri/src/clipboard/clipboard.rs
@@ -18,6 +18,13 @@ fn paste_with_delay(
     app_handle: &tauri::AppHandle,
     macos_delay_ms: u64,
 ) -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        if crate::utils::wayland::is_wayland_session() {
+            return crate::clipboard::clipboard_wayland::paste_wayland(text, app_handle);
+        }
+    }
+
     let app_settings = settings::load_settings(app_handle);
 
     // Direct mode: type text character by character without using clipboard

--- a/src-tauri/src/clipboard/clipboard_wayland.rs
+++ b/src-tauri/src/clipboard/clipboard_wayland.rs
@@ -1,0 +1,41 @@
+use enigo::{Enigo, Keyboard, Settings};
+use log::{debug, warn};
+use tauri_plugin_clipboard_manager::ClipboardExt;
+
+pub fn paste_wayland(text: &str, app_handle: &tauri::AppHandle) -> Result<(), String> {
+    match paste_via_enigo(text) {
+        Ok(()) => {
+            debug!("Wayland: text injected via enigo/libei");
+            Ok(())
+        }
+        Err(e) => {
+            warn!(
+                "Wayland: enigo/libei injection failed ({}), falling back to clipboard",
+                e
+            );
+            paste_via_clipboard(text, app_handle)
+        }
+    }
+}
+
+fn paste_via_enigo(text: &str) -> Result<(), String> {
+    let mut enigo = Enigo::new(&Settings::default())
+        .map_err(|e| format!("Failed to initialize Enigo on Wayland: {}", e))?;
+
+    enigo
+        .text(text)
+        .map_err(|e| format!("Failed to type text on Wayland: {}", e))?;
+
+    Ok(())
+}
+
+fn paste_via_clipboard(text: &str, app_handle: &tauri::AppHandle) -> Result<(), String> {
+    let clipboard = app_handle.clipboard();
+
+    clipboard
+        .write_text(text)
+        .map_err(|e| format!("Failed to write to clipboard on Wayland: {}", e))?;
+
+    warn!("Wayland: text copied to clipboard as fallback, paste manually with Ctrl+V");
+    Ok(())
+}

--- a/src-tauri/src/clipboard/mod.rs
+++ b/src-tauri/src/clipboard/mod.rs
@@ -1,2 +1,6 @@
 pub mod clipboard;
+
+#[cfg(target_os = "linux")]
+pub mod clipboard_wayland;
+
 pub use clipboard::*;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod settings;
 pub mod shortcuts;
 pub mod stats;
 pub mod wake_word;
+pub mod wayland;
 
 pub use clipboard::*;
 pub use dictionary::*;
@@ -27,3 +28,4 @@ pub use settings::*;
 pub use shortcuts::*;
 pub use stats::*;
 pub use wake_word::*;
+pub use wayland::*;

--- a/src-tauri/src/commands/wayland.rs
+++ b/src-tauri/src/commands/wayland.rs
@@ -1,0 +1,11 @@
+#[tauri::command]
+pub fn is_wayland_session() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        crate::utils::wayland::is_wayland_session()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -267,7 +267,8 @@ pub fn run() {
             get_wake_word_validate,
             set_wake_word_validate,
             get_auto_enter_after_wake_word,
-            set_auto_enter_after_wake_word
+            set_auto_enter_after_wake_word,
+            is_wayland_session
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,11 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    #[cfg(target_os = "linux")]
-    {
-        std::env::set_var("GDK_BACKEND", "x11");
-        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-    }
-
     murmure_lib::run()
 }

--- a/src-tauri/src/overlay/overlay.rs
+++ b/src-tauri/src/overlay/overlay.rs
@@ -27,6 +27,12 @@ fn get_cursor_monitor(app_handle: &AppHandle) -> Option<tauri::Monitor> {
 }
 
 fn get_active_monitor(app_handle: &AppHandle) -> Option<tauri::Monitor> {
+    #[cfg(target_os = "linux")]
+    {
+        if crate::utils::wayland::is_wayland_session() {
+            return app_handle.primary_monitor().ok().flatten();
+        }
+    }
     get_cursor_monitor(app_handle).or_else(|| app_handle.primary_monitor().ok().flatten())
 }
 

--- a/src-tauri/src/shortcuts/helpers.rs
+++ b/src-tauri/src/shortcuts/helpers.rs
@@ -169,3 +169,38 @@ pub fn keys_to_string(keys: &[i32]) -> String {
         .collect::<Vec<_>>()
         .join("+")
 }
+
+#[cfg(target_os = "linux")]
+pub fn vk_to_preferred_trigger(vk: i32) -> String {
+    match vk {
+        0x5B => "SUPER".to_string(),
+        0x11 => "CTRL".to_string(),
+        0x12 => "ALT".to_string(),
+        0x10 => "SHIFT".to_string(),
+        0x41..=0x5A => {
+            let offset = (vk - 0x41) as u8;
+            ((b'a' + offset) as char).to_string()
+        }
+        0x30..=0x39 => {
+            let offset = (vk - 0x30) as u8;
+            ((b'0' + offset) as char).to_string()
+        }
+        0x70..=0x83 => format!("F{}", vk - 0x70 + 1),
+        0x20 => "space".to_string(),
+        0x0D => "Return".to_string(),
+        0x1B => "Escape".to_string(),
+        0x09 => "Tab".to_string(),
+        0x08 => "BackSpace".to_string(),
+        0x2E => "Delete".to_string(),
+        0x2D => "Insert".to_string(),
+        0x24 => "Home".to_string(),
+        0x23 => "End".to_string(),
+        0x21 => "Page_Up".to_string(),
+        0x22 => "Page_Down".to_string(),
+        0x26 => "Up".to_string(),
+        0x28 => "Down".to_string(),
+        0x25 => "Left".to_string(),
+        0x27 => "Right".to_string(),
+        _ => vk_to_key_name(vk),
+    }
+}

--- a/src-tauri/src/shortcuts/mod.rs
+++ b/src-tauri/src/shortcuts/mod.rs
@@ -4,7 +4,10 @@ pub mod shortcuts;
 pub mod types;
 
 #[cfg(target_os = "linux")]
-mod platform_linux;
+pub(crate) mod platform_linux;
+
+#[cfg(target_os = "linux")]
+mod platform_linux_wayland;
 
 #[cfg(target_os = "windows")]
 mod platform_windows;

--- a/src-tauri/src/shortcuts/platform_linux_wayland.rs
+++ b/src-tauri/src/shortcuts/platform_linux_wayland.rs
@@ -1,0 +1,151 @@
+use crate::shortcuts::helpers::vk_to_preferred_trigger;
+use crate::shortcuts::types::{KeyEventType, ShortcutBinding};
+use ashpd::desktop::global_shortcuts::{GlobalShortcuts, NewShortcut};
+use futures_util::StreamExt;
+use log::{debug, error, info, warn};
+use tauri::{AppHandle, Manager};
+
+fn build_shortcut_id(index: usize, binding: &ShortcutBinding) -> String {
+    format!("murmure-shortcut-{}-{:?}", index, binding.action)
+}
+
+fn build_preferred_trigger(binding: &ShortcutBinding) -> Option<String> {
+    if binding.keys.is_empty() {
+        return None;
+    }
+    let parts: Vec<String> = binding
+        .keys
+        .iter()
+        .map(|vk| vk_to_preferred_trigger(*vk))
+        .collect();
+    Some(parts.join("+"))
+}
+
+fn collect_new_shortcuts(app: &AppHandle) -> Vec<NewShortcut> {
+    let registry_state = app.state::<crate::shortcuts::registry::ShortcutRegistryState>();
+    let registry = registry_state.0.read();
+
+    registry
+        .bindings
+        .iter()
+        .enumerate()
+        .filter(|(_, b)| !b.keys.is_empty())
+        .map(|(i, binding)| {
+            let id = build_shortcut_id(i, binding);
+            let description = format!("{:?}", binding.action);
+            let mut shortcut = NewShortcut::new(&id, &description);
+            if let Some(trigger) = build_preferred_trigger(binding) {
+                shortcut = shortcut.preferred_trigger(Some(trigger.as_str()));
+            }
+            shortcut
+        })
+        .collect()
+}
+
+pub fn init(app: AppHandle) {
+    std::thread::spawn(move || {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                error!(
+                    "Failed to create tokio runtime for Wayland shortcuts: {}",
+                    e
+                );
+                fallback_to_x11(app);
+                return;
+            }
+        };
+
+        rt.block_on(async move {
+            if let Err(e) = run_wayland_shortcuts(&app).await {
+                warn!(
+                    "GlobalShortcuts portal unavailable, falling back to X11 backend: {}",
+                    e
+                );
+                fallback_to_x11(app);
+            }
+        });
+    });
+}
+
+fn fallback_to_x11(app: AppHandle) {
+    info!("Falling back to rdev (X11/XWayland) shortcut backend");
+    crate::shortcuts::platform_linux::init(app);
+}
+
+async fn run_wayland_shortcuts(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
+    let proxy = GlobalShortcuts::new().await?;
+    let session = proxy.create_session().await?;
+
+    let new_shortcuts = collect_new_shortcuts(app);
+
+    let request = proxy.bind_shortcuts(&session, &new_shortcuts, None).await?;
+    let response = request.response()?;
+
+    info!(
+        "Wayland GlobalShortcuts: {} shortcuts bound via portal",
+        response.shortcuts().len()
+    );
+    for shortcut in response.shortcuts() {
+        debug!("Bound shortcut: {:?}", shortcut);
+    }
+
+    let mut activated_stream = proxy.receive_activated().await?;
+    let mut deactivated_stream = proxy.receive_deactivated().await?;
+
+    loop {
+        tokio::select! {
+            event = activated_stream.next() => {
+                match event {
+                    Some(activated) => {
+                        let shortcut_id = activated.shortcut_id();
+                        debug!("Wayland shortcut activated: {}", shortcut_id);
+                        dispatch_shortcut_event(app, shortcut_id, KeyEventType::Pressed);
+                    }
+                    None => {
+                        warn!("Wayland GlobalShortcuts activated stream ended unexpectedly, falling back to X11");
+                        fallback_to_x11(app.clone());
+                        break Ok(());
+                    }
+                }
+            }
+            event = deactivated_stream.next() => {
+                match event {
+                    Some(deactivated) => {
+                        let shortcut_id = deactivated.shortcut_id();
+                        debug!("Wayland shortcut deactivated: {}", shortcut_id);
+                        dispatch_shortcut_event(app, shortcut_id, KeyEventType::Released);
+                    }
+                    None => {
+                        warn!("Wayland GlobalShortcuts deactivated stream ended unexpectedly, falling back to X11");
+                        fallback_to_x11(app.clone());
+                        break Ok(());
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn dispatch_shortcut_event(app: &AppHandle, shortcut_id: &str, event_type: KeyEventType) {
+    let registry_state = app.state::<crate::shortcuts::registry::ShortcutRegistryState>();
+    let registry = registry_state.0.read();
+
+    for (i, binding) in registry.bindings.iter().enumerate() {
+        let expected_id = build_shortcut_id(i, binding);
+        if expected_id == shortcut_id {
+            crate::shortcuts::handle_shortcut_event(
+                app,
+                &binding.action,
+                &binding.activation_mode,
+                event_type,
+            );
+            return;
+        }
+    }
+
+    warn!("Received unknown Wayland shortcut id: {}", shortcut_id);
+}

--- a/src-tauri/src/shortcuts/shortcuts.rs
+++ b/src-tauri/src/shortcuts/shortcuts.rs
@@ -167,7 +167,11 @@ pub fn init_shortcuts(app: AppHandle) {
     app.manage(ShortcutState::new());
     app.manage(ShortcutRegistryState::new(registry));
 
-    crate::shortcuts::platform_linux::init(app);
+    if crate::utils::wayland::is_wayland_session() {
+        crate::shortcuts::platform_linux_wayland::init(app);
+    } else {
+        crate::shortcuts::platform_linux::init(app);
+    }
 }
 
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,1 +1,4 @@
 pub mod resources;
+
+#[cfg(target_os = "linux")]
+pub mod wayland;

--- a/src-tauri/src/utils/wayland.rs
+++ b/src-tauri/src/utils/wayland.rs
@@ -1,0 +1,22 @@
+use std::sync::OnceLock;
+
+static IS_WAYLAND: OnceLock<bool> = OnceLock::new();
+
+pub fn is_wayland_session() -> bool {
+    *IS_WAYLAND.get_or_init(|| {
+        let session_type = std::env::var("XDG_SESSION_TYPE")
+            .unwrap_or_default()
+            .to_lowercase();
+        let wayland_display = std::env::var("WAYLAND_DISPLAY").is_ok();
+
+        let is_wayland = session_type == "wayland" || wayland_display;
+
+        if is_wayland {
+            log::info!("Session type detected: Wayland");
+        } else {
+            log::info!("Session type detected: X11");
+        }
+
+        is_wayland
+    })
+}

--- a/src/components/hooks/use-is-wayland.ts
+++ b/src/components/hooks/use-is-wayland.ts
@@ -1,0 +1,14 @@
+import { invoke } from '@tauri-apps/api/core';
+import { useEffect, useState } from 'react';
+
+export function useIsWayland(): boolean {
+    const [isWayland, setIsWayland] = useState(false);
+
+    useEffect(() => {
+        invoke<boolean>('is_wayland_session')
+            .then(setIsWayland)
+            .catch(() => setIsWayland(false));
+    }, []);
+
+    return isWayland;
+}

--- a/src/features/settings/system/paste-method-settings/paste-method-settings.tsx
+++ b/src/features/settings/system/paste-method-settings/paste-method-settings.tsx
@@ -13,6 +13,7 @@ import {
     PasteMethod,
     usePasteMethodState,
 } from './hooks/use-paste-method-state';
+import { useIsWayland } from '@/components/hooks/use-is-wayland';
 
 const PASTE_METHODS: { key: PasteMethod; label: string }[] = [
     { key: 'ctrl_v', label: 'Standard (Ctrl+V)' },
@@ -23,6 +24,7 @@ const PASTE_METHODS: { key: PasteMethod; label: string }[] = [
 export const PasteMethodSettings = () => {
     const { t } = useTranslation();
     const { pasteMethod, setPasteMethod } = usePasteMethodState();
+    const isWayland = useIsWayland();
 
     return (
         <SettingsUI.Item>
@@ -32,41 +34,52 @@ export const PasteMethodSettings = () => {
                     {t('Text insertion mode')}
                 </Typography.Title>
                 <Typography.Paragraph>
-                    {t(
-                        'Choose how transcriptions are inserted into applications.'
+                    {isWayland
+                        ? t(
+                              'On Wayland, the text insertion mode is managed automatically.'
+                          )
+                        : t(
+                              'Choose how transcriptions are inserted into applications.'
+                          )}
+                    {!isWayland && (
+                        <ul className="list-disc pl-6 text-xs">
+                            <li>
+                                <span className="font-bold text-sky-400">
+                                    {t('Standard: ')}
+                                </span>
+                                {t(
+                                    'Fast and default option. Works in most applications, but not in terminals.'
+                                )}
+                            </li>
+                            <li>
+                                <span className="font-bold text-sky-400">
+                                    {t('Terminal: ')}
+                                </span>
+                                {t(
+                                    'Designed for terminal applications. May conflict with some software (e.g. LibreOffice).'
+                                )}
+                            </li>
+                            <li>
+                                <span className="font-bold text-sky-400">
+                                    {t('Direct: ')}
+                                </span>
+                                {t(
+                                    'Types text character by character. Works everywhere, but is the slowest option.'
+                                )}
+                            </li>
+                        </ul>
                     )}
-                    <ul className="list-disc pl-6 text-xs">
-                        <li>
-                            <span className="font-bold text-sky-400">
-                                {t('Standard: ')}
-                            </span>
-                            {t(
-                                'Fast and default option. Works in most applications, but not in terminals.'
-                            )}
-                        </li>
-                        <li>
-                            <span className="font-bold text-sky-400">
-                                {t('Terminal: ')}
-                            </span>
-                            {t(
-                                'Designed for terminal applications. May conflict with some software (e.g. LibreOffice).'
-                            )}
-                        </li>
-                        <li>
-                            <span className="font-bold text-sky-400">
-                                {t('Direct: ')}
-                            </span>
-                            {t(
-                                'Types text character by character. Works everywhere, but is the slowest option.'
-                            )}
-                        </li>
-                    </ul>
                 </Typography.Paragraph>
             </SettingsUI.Description>
-            <Select value={pasteMethod} onValueChange={setPasteMethod}>
+            <Select
+                value={pasteMethod}
+                onValueChange={setPasteMethod}
+                disabled={isWayland}
+            >
                 <SelectTrigger
                     className="w-[200px]"
                     data-testid="paste-method-select"
+                    disabled={isWayland}
                 >
                     <SelectValue />
                 </SelectTrigger>

--- a/src/features/voice-mode/voice-mode.tsx
+++ b/src/features/voice-mode/voice-mode.tsx
@@ -10,11 +10,13 @@ import { useWakeWord, WAKE_WORD_CONFIGS } from './hooks/use-wake-word';
 import { VoiceTriggerItem } from './voice-trigger-item/voice-trigger-item';
 import { VoiceModeCta } from './voice-mode-cta/voice-mode-cta';
 import { LlmConnectTriggers } from './llm-connect-triggers/llm-connect-triggers';
+import { useIsWayland } from '@/components/hooks/use-is-wayland';
 
 export const VoiceMode = () => {
     const { t } = useTranslation();
     const { enabled, setEnabled } = useWakeWordEnabled();
     const { autoEnter, setAutoEnter } = useAutoEnter();
+    const isWayland = useIsWayland();
 
     const {
         wakeWord: recordWakeWord,
@@ -115,7 +117,6 @@ export const VoiceMode = () => {
                                     onWakeWordChange={setRecordWakeWord}
                                     onBlur={handleRecordBlur}
                                     placeholder="ok alix"
-
                                     dataTestId="wake-word-record-input"
                                     isEnabled={recordEnabled}
                                     onToggleEnabled={toggleRecord}
@@ -132,7 +133,6 @@ export const VoiceMode = () => {
                                     onWakeWordChange={setCommandWakeWord}
                                     onBlur={handleCommandBlur}
                                     placeholder="alix command"
-
                                     dataTestId="wake-word-command-input"
                                     isEnabled={commandEnabled}
                                     onToggleEnabled={toggleCommand}
@@ -149,62 +149,68 @@ export const VoiceMode = () => {
                                     onWakeWordChange={setCancelWakeWord}
                                     onBlur={handleCancelBlur}
                                     placeholder="alix cancel"
-
                                     dataTestId="wake-word-cancel-input"
                                     isEnabled={cancelEnabled}
                                     onToggleEnabled={toggleCancel}
                                     defaultWord={cancelDefault}
                                     onReset={resetCancel}
                                 />
-                                <SettingsUI.Separator />
-                                <VoiceTriggerItem
-                                    title={t('Validate')}
-                                    description={t(
-                                        'Say the trigger word to stop recording, transcribe, and press Enter'
-                                    )}
-                                    wakeWord={validateWakeWord}
-                                    onWakeWordChange={setValidateWakeWord}
-                                    onBlur={handleValidateBlur}
-                                    placeholder="alix validate"
-
-                                    dataTestId="wake-word-validate-input"
-                                    isEnabled={validateEnabled}
-                                    onToggleEnabled={toggleValidate}
-                                    defaultWord={validateDefault}
-                                    onReset={resetValidate}
-                                />
+                                {!isWayland && (
+                                    <>
+                                        <SettingsUI.Separator />
+                                        <VoiceTriggerItem
+                                            title={t('Validate')}
+                                            description={t(
+                                                'Say the trigger word to stop recording, transcribe, and press Enter'
+                                            )}
+                                            wakeWord={validateWakeWord}
+                                            onWakeWordChange={
+                                                setValidateWakeWord
+                                            }
+                                            onBlur={handleValidateBlur}
+                                            placeholder="alix validate"
+                                            dataTestId="wake-word-validate-input"
+                                            isEnabled={validateEnabled}
+                                            onToggleEnabled={toggleValidate}
+                                            defaultWord={validateDefault}
+                                            onReset={resetValidate}
+                                        />
+                                    </>
+                                )}
                             </SettingsUI.Container>
                         </section>
 
                         <LlmConnectTriggers />
 
-                        <section>
-                            <Typography.Title
-                                data-testid="behavior-title"
-                                className="p-2 font-semibold text-sky-400!"
-                            >
-                                {t('Behavior')}
-                            </Typography.Title>
-                            <SettingsUI.Container>
-                                <SettingsUI.Item>
-                                    <SettingsUI.Description>
-                                        <Typography.Title>
-                                            {t('Auto-press Enter')}
-                                        </Typography.Title>
-                                        <Typography.Paragraph>
-                                            {t(
-                                                'Automatically press Enter after pasting the transcription. Useful for chat apps and search bars.'
-                                            )}
-                                        </Typography.Paragraph>
-                                    </SettingsUI.Description>
-                                    <Switch
-                                        checked={autoEnter}
-                                        onCheckedChange={setAutoEnter}
-                                        data-testid="auto-enter-toggle"
-                                    />
-                                </SettingsUI.Item>
-                            </SettingsUI.Container>
-                        </section>
+                        {!isWayland && (
+                            <section>
+                                <Typography.Title
+                                    data-testid="behavior-title"
+                                    className="p-2 font-semibold text-sky-400!"
+                                >
+                                    {t('Behavior')}
+                                </Typography.Title>
+                                <SettingsUI.Container>
+                                    <SettingsUI.Item>
+                                        <SettingsUI.Description>
+                                            <Typography.Title>
+                                                {t('Auto-press Enter')}
+                                            </Typography.Title>
+                                            <Typography.Paragraph>
+                                                {t(
+                                                    'Automatically press Enter after pasting the transcription. Useful for chat apps and search bars.'
+                                                )}
+                                            </Typography.Paragraph>
+                                        </SettingsUI.Description>
+                                        <Switch
+                                            checked={autoEnter}
+                                            onCheckedChange={setAutoEnter}
+                                            data-testid="auto-enter-toggle"
+                                        />
+                                    </SettingsUI.Item>
+                                </SettingsUI.Container>
+                            </section>
+                        )}
                     </>
                 ) : (
                     <VoiceModeCta />


### PR DESCRIPTION
## Description

Add native Wayland support for GNOME sessions (Ubuntu 24.04+, Fedora 40+). Runtime detection via `XDG_SESSION_TYPE` and `WAYLAND_DISPLAY` environment variables, with full X11 backward compatibility.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other:

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [GUIDELINES.md](../GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [ ] I checked for SonarQube issues on the draft PR

## Screenshots (if applicable)

N/A