### PR TITLE
fix(settings): handle empty mic_id to prevent System page crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,12 @@ See [CHANGELOG.md](./CHANGELOG.md).
 - [x] (1.8.0) fix(settings): improve microphone list and keep manually selected device when disconnected
 - [x] (1.8.0) fix(llm-connect): Improve the accuracy and instruction-following capabilities of local LLMs by using system prompts.  
 - [x] (1.8.0) fix(llm-connect): Significantly improve the response speed of reasoning models by disabling thinking mode. (Qwen 3.5, Ministral, etc.)
-- [ ] (1.8.0) feat(overlay): Configure overlay size
+- [x] (1.8.0) fix(settings): Crash when no microphone is available
 - [ ] feat(shortcuts): using delete should remove shortcuts
 - [ ] fix(shortcuts): Do not allow adding duplicate shortcuts
 - [ ] feat(dictionary): Virtualize dictionary to handle large dictionaries
 - [ ] feat(llm): Automatically detect Ollama at first LLM Connect tutorial.
+- [ ] feat(overlay): Configure overlay size
 - [ ] feat(overlay): Allow dragging the overlay to change its position https://github.com/Kieirra/murmure/issues/64
 - [ ] feat(dictionary): Improve detection https://github.com/Kieirra/murmure/issues/44
 - [ ] fix(visualizer): Adjust sensitivity (dynamic or lower)

--- a/src/features/settings/system/mic-settings/hooks/use-mic-state.ts
+++ b/src/features/settings/system/mic-settings/hooks/use-mic-state.ts
@@ -53,7 +53,7 @@ export const useMicState = () => {
                     invoke<string | null>('get_current_mic_id'),
                     invoke<string | null>('get_current_mic_label'),
                 ]);
-                const micId = id ?? AUTOMATIC_MIC_ID;
+                const micId = id || AUTOMATIC_MIC_ID;
                 setCurrentMic(micId);
 
                 if (label) {


### PR DESCRIPTION
## Description

Fix crash on Paramètres > Système when `mic_id` is an empty string in settings. Replace `??` with `||` so empty strings fall back to `AUTOMATIC_MIC_ID` instead of creating a `<SelectItem value="">` which Radix UI forbids.
fix: https://github.com/Kieirra/murmure/issues/215

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other:

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [GUIDELINES.md](../GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [x] I checked for SonarQube issues on the draft PR