### PR TITLE
feat(shortcuts): add support for OEM keys and fix digit row on non-US layouts

### DIFF
--- a/src-tauri/src/shortcuts/helpers.rs
+++ b/src-tauri/src/shortcuts/helpers.rs
@@ -94,6 +94,17 @@ fn key_name_to_vk(name: &str) -> Option<i32> {
         "arrowdown" | "down" => Some(0x28),
         "arrowleft" | "left" => Some(0x25),
         "arrowright" | "right" => Some(0x27),
+        // OEM keys
+        "minus" | "-" => Some(0xBD),
+        "equal" | "=" => Some(0xBB),
+        "bracketleft" | "[" => Some(0xDB),
+        "bracketright" | "]" => Some(0xDD),
+        "semicolon" | ";" => Some(0xBA),
+        "quote" | "'" => Some(0xDE),
+        "comma" | "," => Some(0xBC),
+        "period" | "." => Some(0xBE),
+        "slash" | "/" => Some(0xBF),
+        "backslash" | "\\" => Some(0xDC),
         "mousebutton1" => Some(0x01), // VK_LBUTTON
         "mousebutton2" => Some(0x02), // VK_RBUTTON
         "mousebutton3" => Some(0x04), // VK_MBUTTON
@@ -142,6 +153,17 @@ fn vk_to_key_name(vk: i32) -> String {
         0x28 => "arrowdown".to_string(),
         0x25 => "arrowleft".to_string(),
         0x27 => "arrowright".to_string(),
+        // OEM keys
+        0xBD => "minus".to_string(),
+        0xBB => "equal".to_string(),
+        0xDB => "bracketleft".to_string(),
+        0xDD => "bracketright".to_string(),
+        0xBA => "semicolon".to_string(),
+        0xDE => "quote".to_string(),
+        0xBC => "comma".to_string(),
+        0xBE => "period".to_string(),
+        0xBF => "slash".to_string(),
+        0xDC => "backslash".to_string(),
         0x01 => "mousebutton1".to_string(),
         0x02 => "mousebutton2".to_string(),
         0x04 => "mousebutton3".to_string(),

--- a/src-tauri/src/shortcuts/platform_linux.rs
+++ b/src-tauri/src/shortcuts/platform_linux.rs
@@ -277,6 +277,17 @@ fn rdev_key_to_vk(key: &Key) -> Option<i32> {
         Key::DownArrow => Some(0x28),
         Key::LeftArrow => Some(0x25),
         Key::RightArrow => Some(0x27),
+        // OEM keys
+        Key::Minus => Some(0xBD),
+        Key::Equal => Some(0xBB),
+        Key::LeftBracket => Some(0xDB),
+        Key::RightBracket => Some(0xDD),
+        Key::SemiColon => Some(0xBA),
+        Key::Quote => Some(0xDE),
+        Key::Comma => Some(0xBC),
+        Key::Dot => Some(0xBE),
+        Key::Slash => Some(0xBF),
+        Key::BackSlash => Some(0xDC),
         _ => None,
     }
 }

--- a/src-tauri/src/shortcuts/platform_macos.rs
+++ b/src-tauri/src/shortcuts/platform_macos.rs
@@ -463,6 +463,17 @@ fn char_to_vk(c: char) -> Option<i32> {
         '8' => Some(0x38),
         '9' => Some(0x39),
         ' ' => Some(0x20),
+        // OEM characters
+        '-' => Some(0xBD),
+        '=' => Some(0xBB),
+        '[' => Some(0xDB),
+        ']' => Some(0xDD),
+        ';' => Some(0xBA),
+        '\'' => Some(0xDE),
+        ',' => Some(0xBC),
+        '.' => Some(0xBE),
+        '/' => Some(0xBF),
+        '\\' => Some(0xDC),
         _ => None,
     }
 }
@@ -564,6 +575,17 @@ fn rdev_key_to_vk(key: &Key) -> Option<i32> {
         Key::DownArrow => Some(0x28),
         Key::LeftArrow => Some(0x25),
         Key::RightArrow => Some(0x27),
+        // OEM keys
+        Key::Minus => Some(0xBD),
+        Key::Equal => Some(0xBB),
+        Key::LeftBracket => Some(0xDB),
+        Key::RightBracket => Some(0xDD),
+        Key::SemiColon => Some(0xBA),
+        Key::Quote => Some(0xDE),
+        Key::Comma => Some(0xBC),
+        Key::Dot => Some(0xBE),
+        Key::Slash => Some(0xBF),
+        Key::BackSlash => Some(0xDC),
         _ => None,
     }
 }

--- a/src/components/render-keys.tsx
+++ b/src/components/render-keys.tsx
@@ -45,6 +45,17 @@ const KEY_LABELS: Record<string, string> = {
     // Special keys
     backquote: '²',
     intlbackslash: '<>',
+    // OEM keys
+    minus: '-',
+    equal: '=',
+    bracketleft: '[',
+    bracketright: ']',
+    semicolon: ';',
+    quote: "'",
+    comma: ',',
+    period: '.',
+    slash: '/',
+    backslash: '\\',
 };
 
 interface RenderKeysProps extends React.HTMLAttributes<HTMLSpanElement> {

--- a/src/features/settings/shortcuts/shortcut-button/hooks/use-shortcut-interactions.ts
+++ b/src/features/settings/shortcuts/shortcut-button/hooks/use-shortcut-interactions.ts
@@ -43,6 +43,16 @@ const NUMPAD_CODE_MAP: Record<string, string> = {
 const SPECIAL_KEY_CODE_MAP: Record<string, string> = {
     Backquote: 'backquote',
     IntlBackslash: 'intlbackslash',
+    Minus: 'minus',
+    Equal: 'equal',
+    BracketLeft: 'bracketleft',
+    BracketRight: 'bracketright',
+    Semicolon: 'semicolon',
+    Quote: 'quote',
+    Comma: 'comma',
+    Period: 'period',
+    Slash: 'slash',
+    Backslash: 'backslash',
 };
 
 const MOUSE_BUTTON_MAP: Record<number, string> = {
@@ -71,10 +81,10 @@ export const useShortcutInteractions = (
         // Special keys: use e.code for physical position (layout-independent)
         const specialKey = SPECIAL_KEY_CODE_MAP[code];
         if (specialKey != null) return specialKey;
+        // Digit row: use e.code for layout independence (AZERTY sends é, ", etc. instead of digits)
+        if (code.startsWith('Digit')) return code.charAt(5);
         if (key.length === 1) return key.toLowerCase();
         if (key.startsWith('F') && key.length <= 3) return key.toLowerCase();
-        if (key.startsWith('Digit')) return key.replace('Digit', '');
-        if (key.startsWith('Key')) return key.replace('Key', '').toLowerCase();
         return key.toLowerCase();
     };
 


### PR DESCRIPTION
## Description

Add support for 10 OEM keys (Minus, Equal, BracketLeft, BracketRight, Semicolon, Quote, Comma, Period, Slash, Backslash) in the shortcut system, and fix digit row normalization for non-US keyboard layouts (AZERTY, etc.).

fix: https://github.com/Kieirra/murmure/issues/216

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other:

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [GUIDELINES.md](../GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [x] I checked for SonarQube issues on the draft PR