### PR TITLE
fix(rules): improve smart mode auto-spacing, add parakeet dedup, translate tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ See [CHANGELOG.md](./CHANGELOG.md).
 - [x] (1.8.0) fix(llm-connect): Improve the accuracy and instruction-following capabilities of local LLMs by using system prompts.  
 - [x] (1.8.0) fix(llm-connect): Significantly improve the response speed of reasoning models by disabling thinking mode. (Qwen 3.5, Ministral, etc.)
 - [x] (1.8.0) fix(settings): Crash when no microphone is available
+- [x] (1.8.0) feat(shortcuts): Add support for OEM keys (-, =, [, ], ;, ', ,, ., /, \) and fix digit row on all keyboard layouts
+- [x] (1.8.0) fix(rules): Improve smart mode auto-spacing and add word deduplication (parakeet fix)
 - [ ] feat(shortcuts): using delete should remove shortcuts
 - [ ] fix(shortcuts): Do not allow adding duplicate shortcuts
 - [ ] feat(dictionary): Virtualize dictionary to handle large dictionaries

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -23,18 +23,21 @@ pub fn process_recording(app: &AppHandle, file_path: &Path) -> Result<String> {
         return Ok(raw_text);
     }
 
-    // 2. Dictionary & CC Rules
-    let text = apply_dictionary_and_rules(app, raw_text)?;
+    // 2. Deduplicate repeated words (transcription artifact cleanup)
+    let text = deduplicate_repeated_words(&raw_text);
+
+    // 3. Dictionary & CC Rules
+    let text = apply_dictionary_and_rules(app, text)?;
     debug!("Transcription fixed with dictionary: {}", text);
 
-    // 3. LLM Post-processing
+    // 4. LLM Post-processing
     let llm_text = apply_llm_processing(app, text)?;
 
-    // 4. Apply formatting rules
+    // 5. Apply formatting rules
     let final_text = apply_formatting_rules(app, llm_text);
     debug!("Transcription with formatting rules: {}", final_text);
 
-    // 5. Save Stats & History
+    // 6. Save Stats & History
     save_stats_and_history(app, file_path, &final_text)?;
 
     Ok(final_text)
@@ -191,6 +194,38 @@ fn apply_formatting_rules(app: &AppHandle, text: String) -> String {
     }
 }
 
+fn deduplicate_repeated_words(text: &str) -> String {
+    let words: Vec<&str> = text.split_whitespace().collect();
+    if words.is_empty() {
+        return String::new();
+    }
+
+    let mut result: Vec<&str> = Vec::with_capacity(words.len());
+    let mut i = 0;
+
+    while i < words.len() {
+        let current_lower = words[i].to_lowercase();
+        let mut count = 1;
+
+        while i + count < words.len() && words[i + count].to_lowercase() == current_lower {
+            count += 1;
+        }
+
+        if count >= 3 {
+            result.push(words[i]);
+            result.push(words[i + 1]);
+        } else {
+            for j in 0..count {
+                result.push(words[i + j]);
+            }
+        }
+
+        i += count;
+    }
+
+    result.join(" ")
+}
+
 fn save_stats_and_history(app: &AppHandle, file_path: &Path, text: &str) -> Result<()> {
     // Calculate duration and size
     let (duration_seconds, wav_size_bytes) = match hound::WavReader::open(file_path) {
@@ -221,4 +256,77 @@ fn save_stats_and_history(app: &AppHandle, file_path: &Path, text: &str) -> Resu
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_four_to_two() {
+        assert_eq!(
+            deduplicate_repeated_words("je je je je vais"),
+            "je je vais"
+        );
+    }
+
+    #[test]
+    fn dedup_two_kept_unchanged() {
+        assert_eq!(deduplicate_repeated_words("oui oui"), "oui oui");
+    }
+
+    #[test]
+    fn dedup_five_to_two() {
+        assert_eq!(
+            deduplicate_repeated_words("the the the the the cat"),
+            "the the cat"
+        );
+    }
+
+    #[test]
+    fn dedup_three_to_two_case_insensitive() {
+        assert_eq!(
+            deduplicate_repeated_words("Hello HELLO hello world"),
+            "Hello HELLO world"
+        );
+    }
+
+    #[test]
+    fn dedup_no_repetition() {
+        assert_eq!(
+            deduplicate_repeated_words("normal sentence"),
+            "normal sentence"
+        );
+    }
+
+    #[test]
+    fn dedup_empty_string() {
+        assert_eq!(deduplicate_repeated_words(""), "");
+    }
+
+    #[test]
+    fn dedup_single_word() {
+        assert_eq!(deduplicate_repeated_words("word"), "word");
+    }
+
+    #[test]
+    fn dedup_multiple_groups() {
+        assert_eq!(
+            deduplicate_repeated_words("the the the cat the the the dog"),
+            "the the cat the the dog"
+        );
+    }
+
+    #[test]
+    fn dedup_exactly_three_to_two() {
+        assert_eq!(
+            deduplicate_repeated_words("hello hello hello world"),
+            "hello hello world"
+        );
+    }
+
+    #[test]
+    fn dedup_one_occurrence_unchanged() {
+        assert_eq!(deduplicate_repeated_words("hello world"), "hello world");
+    }
 }

--- a/src-tauri/src/formatting_rules/formatter.rs
+++ b/src-tauri/src/formatting_rules/formatter.rs
@@ -135,11 +135,16 @@ fn apply_custom_rule(
         MatchMode::Smart => {
             let escaped_trigger = regex::escape(trigger);
             let pattern = format!(
-                r"(?i)(?:[,\.]\s|\s)?{escaped}[,\.]?",
+                r"(?i)(?P<pre>(?:[,\.]\s|\s)?){escaped}[,\.]?",
                 escaped = escaped_trigger
             );
             match Regex::new(&pattern) {
-                Ok(re) => re.replace_all(text, replacement).to_string(),
+                Ok(re) if replacement.is_empty() => re.replace_all(text, "").to_string(),
+                Ok(re) => {
+                    let escaped = replacement.replace("$", "$$");
+                    let replacement = format!("${{pre}}{}", escaped);
+                    re.replace_all(text, replacement.as_str()).to_string()
+                }
                 Err(_) => text.to_string(),
             }
         }
@@ -284,4 +289,55 @@ mod tests {
                 .contains("Un deux trois quatre cinq six.")
         );
     }
+
+    // Tests for Smart mode auto-spacing
+    #[test]
+    fn smart_mode_preserves_space_mid_sentence() {
+        let result = apply_custom_rule("I'm gonna go", "gonna", "going to", &MatchMode::Smart);
+        assert_eq!(result, "I'm going to go");
+    }
+
+    #[test]
+    fn smart_mode_no_leading_space_at_start() {
+        let result = apply_custom_rule("Gonna go now", "gonna", "going to", &MatchMode::Smart);
+        assert_eq!(result, "going to go now");
+    }
+
+    #[test]
+    fn smart_mode_preserves_punctuation_prefix() {
+        let result =
+            apply_custom_rule("hello, gonna go", "gonna", "going to", &MatchMode::Smart);
+        assert_eq!(result, "hello, going to go");
+    }
+
+    #[test]
+    fn smart_mode_leading_space_in_replacement_is_preserved() {
+        let result = apply_custom_rule("I'm gonna go", "gonna", " going to", &MatchMode::Smart);
+        assert_eq!(result, "I'm  going to go");
+    }
+
+    #[test]
+    fn smart_mode_empty_replacement_deletes_with_space() {
+        let result = apply_custom_rule("hello world foo", "world", "", &MatchMode::Smart);
+        assert_eq!(result, "hello foo");
+    }
+
+    #[test]
+    fn smart_mode_empty_replacement_at_start() {
+        let result = apply_custom_rule("world foo", "world", "", &MatchMode::Smart);
+        assert_eq!(result, " foo");
+    }
+
+    #[test]
+    fn smart_mode_case_insensitive() {
+        let result = apply_custom_rule("Hello WORLD test", "world", "earth", &MatchMode::Smart);
+        assert_eq!(result, "Hello earth test");
+    }
+
+    #[test]
+    fn smart_mode_strips_trailing_punctuation() {
+        let result = apply_custom_rule("hello world.", "world", "earth", &MatchMode::Smart);
+        assert_eq!(result, "hello earth");
+    }
+
 }

--- a/src/features/layout/app-sidebar/app-sidebar.tsx
+++ b/src/features/layout/app-sidebar/app-sidebar.tsx
@@ -176,7 +176,7 @@ export const AppSidebar = () => {
             </SidebarContent>
             <SidebarFooter className="bg-background ">
                 <a
-                    href="https://github.com/Kieirra/murmure/releases/latest"
+                    href={version.length > 0 ? `https://github.com/Kieirra/murmure/releases/tag/${version}` : 'https://github.com/Kieirra/murmure/releases/latest'}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-muted-foreground text-xs hover:text-foreground transition-colors flex items-center gap-2 px-2"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -428,5 +428,12 @@
     "Connection Settings": "Paramètres de connexion",
     "Update Murmure": "Mettre à jour Murmure",
     "Configuration exported to {{path}}.": "Configuration exportée vers {{path}}.",
-    "more...": "plus..."
+    "more...": "plus...",
+    "Smart": "Smart",
+    "Exact": "Exact",
+    "Regex": "Regex",
+    "Handles surrounding punctuation and case-insensitive.": "Gère la ponctuation environnante et insensible à la casse.",
+    "Matches the exact text, case-sensitive.": "Correspond au texte exact, sensible à la casse.",
+    "Use a regular expression pattern. Case-sensitive by default, add (?i) for case-insensitive.": "Utilise une expression régulière. Sensible à la casse par défaut, ajoutez (?i) pour l'insensibilité.",
+    "Use real line breaks (Enter key) to insert new lines, not \\n.": "Utilisez de vrais sauts de ligne (touche Entrée), pas \\n."
 }


### PR DESCRIPTION
## Description

Four minor fixes grouped in one PR: smart mode auto-spacing with named regex capture group, word deduplication for parakeet hallucinations (3+ → 2), French translations for formatting rule tooltips, and versioned release notes link.

## Type of change

- [x] Bug fix
- [x] Enhancement of an existing feature

## Tested on

- [x] Linux

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [GUIDELINES.md](../GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [x] I checked for SonarQube issues on the draft PR