### PR TITLE
fix(shortcuts): correct spurious modifier key release on macOS after paste (#234)

### DIFF
--- a/src-tauri/src/shortcuts/platform_macos.rs
+++ b/src-tauri/src/shortcuts/platform_macos.rs
@@ -155,7 +155,25 @@ impl EventProcessor {
     }
 
     fn handle_key_release(&self, key: i32) {
-        self.pressed_keys.lock().remove(&key);
+        let mut pressed = self.pressed_keys.lock();
+        if !pressed.remove(&key) {
+            // Fix #234: After Enigo simulates Cmd+V to paste, macOS corrupts
+            // its modifier flags, causing rdev to report the next real modifier
+            // press as a release. A release for an unpressed modifier key is
+            // physically impossible, so we correct it back to a press.
+            const MODIFIER_VK_CODES: &[i32] = &[0x11, 0x10, 0x12, 0x5B];
+            if MODIFIER_VK_CODES.contains(&key) {
+                trace!(
+                    "[macOS shortcuts] Correcting spurious release for modifier 0x{:X} (not in pressed_keys), treating as press",
+                    key
+                );
+                pressed.insert(key);
+                drop(pressed);
+                self.check_press();
+                return;
+            }
+        }
+        drop(pressed);
         self.check_release();
     }
 


### PR DESCRIPTION
## Summary

- Fixes #234: on macOS, after Enigo simulates Cmd+V to paste a transcription, the OS modifier flags get corrupted. This causes rdev to report the next real modifier key press (Ctrl, Option, Shift, Cmd) as a release, breaking push-to-talk shortcuts every other time.
- The fix detects "release without prior press" events for modifier keys (physically impossible) and corrects them back to a press.
- Only affects macOS. No impact on Windows/Linux. Users not experiencing the bug are unaffected (the fix code path is never reached in normal operation).

## Test plan

- [ ] macOS: configure a push-to-talk shortcut with modifier keys (e.g., Ctrl+Option), verify it fires every time (not every other time)
- [ ] macOS: verify direct type mode still works
- [ ] macOS: verify non-modifier shortcuts still work
- [ ] Windows/Linux: verify no regression on shortcut behavior