### PR TITLE
Update links in PR template for CONTRIBUTING and GUIDELINES

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@
 
 ## Checklist
 
-- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [GUIDELINES.md](../GUIDELINES.md)
+- [ ] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
 - [ ] My PR addresses **one single concern**
 - [ ] I tested my changes manually and they work as expected
 - [ ] I ran `cargo clippy` and `cargo fmt` (if Rust changes)


### PR DESCRIPTION
## Description

Depending on where/when you read the PR template, the links my be wrong. For example, if you open:

* `https://github.com/Kieirra/murmure/pull/296` the link goes to https://github.com/Kieirra/murmure/CONTRIBUTING.md
* `https://github.com/Kieirra/murmure/pull/296/` the link goes to https://github.com/Kieirra/murmure/pull/CONTRIBUTING.md

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [X] Documentation
- [ ] Other: <!-- specify -->

## Tested on

- [ ] Windows
- [ ] Linux
- [ ] macOS

## Checklist

- [ ] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [ ] My PR addresses **one single concern**
- [ ] I tested my changes manually and they work as expected
- [ ] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [ ] I checked for SonarQube issues on the draft PR

## Screenshots (if applicable)

<!-- Paste screenshots here or remove this section. -->
