### PR TITLE
perf(cache): in-memory caching to skip disk/JSON on hot paths

### DIFF
--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -1,6 +1,6 @@
 use crate::audio::helpers::read_wav_samples;
 use crate::audio::types::{AudioState, RecordingMode};
-use crate::dictionary::{fix_transcription_with_dictionary, get_cc_rules_path, Dictionary};
+use crate::dictionary::{fix_transcription_with_dictionary, get_cc_rules_path};
 use crate::engine::transcription_engine::TranscriptionEngine;
 use crate::engine::ParakeetModelParams;
 use crate::formatting_rules;
@@ -80,7 +80,7 @@ pub fn transcribe_audio(app: &AppHandle, audio_path: &Path) -> Result<String> {
 
 fn apply_dictionary_and_rules(app: &AppHandle, text: String) -> Result<String> {
     let cc_rules_path = get_cc_rules_path(app).context("Failed to get CC rules path")?;
-    let dictionary = app.state::<Dictionary>();
+    let dictionary = crate::dictionary::store::current(app);
 
     Ok(fix_transcription_with_dictionary(
         text,

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -80,7 +80,7 @@ pub fn transcribe_audio(app: &AppHandle, audio_path: &Path) -> Result<String> {
 
 fn apply_dictionary_and_rules(app: &AppHandle, text: String) -> Result<String> {
     let cc_rules_path = get_cc_rules_path(app).context("Failed to get CC rules path")?;
-    let dictionary = app.state::<Dictionary>().get();
+    let dictionary = app.state::<Dictionary>();
 
     Ok(fix_transcription_with_dictionary(
         text,

--- a/src-tauri/src/audio/streaming.rs
+++ b/src-tauri/src/audio/streaming.rs
@@ -179,7 +179,7 @@ pub fn start_streaming(app: &AppHandle, audio_state: &AudioState, sample_rate: u
         }
     };
 
-    let dictionary = app.state::<Dictionary>().inner().clone();
+    let dictionary = crate::dictionary::store::current(app);
     let cc_rules_path = get_cc_rules_path(app).ok();
 
     // Reset the overlay text immediately before starting a new streaming session

--- a/src-tauri/src/audio/streaming.rs
+++ b/src-tauri/src/audio/streaming.rs
@@ -357,10 +357,8 @@ fn correct_with_dictionary(
     cc_rules_path: &Option<PathBuf>,
 ) -> String {
     match cc_rules_path {
-        Some(path) if !dictionary.words.lock().is_empty() => {
-            fix_transcription_with_dictionary(text.to_string(), dictionary, path)
-        }
-        _ => text.to_string(),
+        Some(path) => fix_transcription_with_dictionary(text.to_string(), dictionary, path),
+        None => text.to_string(),
     }
 }
 

--- a/src-tauri/src/audio/streaming.rs
+++ b/src-tauri/src/audio/streaming.rs
@@ -10,7 +10,6 @@ use crate::overlay::overlay;
 use log::{debug, error, warn};
 use parking_lot::Mutex;
 use serde::Serialize;
-use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -180,7 +179,7 @@ pub fn start_streaming(app: &AppHandle, audio_state: &AudioState, sample_rate: u
         }
     };
 
-    let dictionary = app.state::<Dictionary>().get();
+    let dictionary = app.state::<Dictionary>().inner().clone();
     let cc_rules_path = get_cc_rules_path(app).ok();
 
     // Reset the overlay text immediately before starting a new streaming session
@@ -238,7 +237,7 @@ struct StreamingLoopParams {
     stop: Arc<AtomicBool>,
     sample_rate: u32,
     formatting_settings: formatting_rules::FormattingSettings,
-    dictionary: HashMap<String, Vec<String>>,
+    dictionary: Dictionary,
     cc_rules_path: Option<PathBuf>,
     chars_per_line: usize,
     max_lines: u32,
@@ -354,11 +353,11 @@ fn streaming_thread_loop(params: StreamingLoopParams) {
 
 fn correct_with_dictionary(
     text: &str,
-    dictionary: &HashMap<String, Vec<String>>,
+    dictionary: &Dictionary,
     cc_rules_path: &Option<PathBuf>,
 ) -> String {
     match cc_rules_path {
-        Some(path) if !dictionary.is_empty() => {
+        Some(path) if !dictionary.words.lock().unwrap().is_empty() => {
             fix_transcription_with_dictionary(text.to_string(), dictionary, path)
         }
         _ => text.to_string(),

--- a/src-tauri/src/audio/streaming.rs
+++ b/src-tauri/src/audio/streaming.rs
@@ -357,7 +357,7 @@ fn correct_with_dictionary(
     cc_rules_path: &Option<PathBuf>,
 ) -> String {
     match cc_rules_path {
-        Some(path) if !dictionary.words.lock().unwrap().is_empty() => {
+        Some(path) if !dictionary.words.lock().is_empty() => {
             fix_transcription_with_dictionary(text.to_string(), dictionary, path)
         }
         _ => text.to_string(),

--- a/src-tauri/src/cli/import.rs
+++ b/src-tauri/src/cli/import.rs
@@ -2,10 +2,9 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use log::info;
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter};
 
 use super::types::{ImportStrategy, MurmureExportData};
-use crate::dictionary::Dictionary;
 use crate::formatting_rules::types::FormattingSettings;
 use crate::llm::types::LLMConnectSettings;
 
@@ -309,16 +308,7 @@ pub fn apply_hot_reload_side_effects(app: &AppHandle) {
 
     crate::llm::helpers::restart_wake_word_if_active(app);
 
-    match crate::dictionary::store::load(app) {
-        Ok(dict) => {
-            let dictionary_state = app.state::<Dictionary>();
-            dictionary_state.set(dict);
-            let _ = app.emit("dictionary:updated", ());
-        }
-        Err(e) => {
-            log::error!("Failed to reload dictionary after CLI import: {}", e);
-        }
-    }
+    let _ = app.emit("dictionary:updated", ());
 
     let _ = app.emit("config-imported", ());
 

--- a/src-tauri/src/dictionary/dictionary.rs
+++ b/src-tauri/src/dictionary/dictionary.rs
@@ -1,47 +1,60 @@
 use crate::dictionary::types::Dictionary;
-use log::debug;
+use log::{debug, warn};
 use once_cell::sync::OnceCell;
 use rphonetic::{BeiderMorseBuilder, ConfigFiles, LanguageSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::AppHandle;
 
 /// Cached resolved path to the bundled `cc-rules/` directory.
 /// Populated on the first successful `get_cc_rules_path` call; subsequent
 /// calls return the cached value without re-walking the Tauri resource paths.
-/// Failures do not poison the cache — a transient resource-resolution error
-/// leaves the cell empty and the next call retries.
+/// If init fails, the cell stays empty (OnceCell is not populated with an
+/// error) and the next call retries.
 static CC_RULES_PATH: OnceCell<PathBuf> = OnceCell::new();
 
+/// Parsed BeiderMorse XML rules kept for the whole process life. When init
+/// fails (corrupt bundle), the caller falls back to returning the input
+/// transcription unchanged rather than panicking.
 static CONFIG_FILES: OnceCell<ConfigFiles> = OnceCell::new();
 
-fn get_or_init_config_files(cc_rules_path: &PathBuf) -> &'static ConfigFiles {
-    CONFIG_FILES.get_or_init(|| {
-        ConfigFiles::new(cc_rules_path).expect("Failed to load BeiderMorse config files")
-    })
+fn get_or_init_config_files(cc_rules_path: &Path) -> Option<&'static ConfigFiles> {
+    if let Some(files) = CONFIG_FILES.get() {
+        return Some(files);
+    }
+    let path_buf = cc_rules_path.to_path_buf();
+    match ConfigFiles::new(&path_buf) {
+        Ok(files) => Some(CONFIG_FILES.get_or_init(|| files)),
+        Err(e) => {
+            warn!(
+                "BeiderMorse config files failed to load at {:?}: {}. Phonetic correction skipped.",
+                cc_rules_path, e
+            );
+            None
+        }
+    }
 }
 
-/**
- * Use phonetic algorithm to fix the transcription
- */
 pub fn fix_transcription_with_dictionary(
     transcription: String,
     dictionary: &Dictionary,
-    cc_rules_path: &PathBuf,
+    cc_rules_path: &Path,
 ) -> String {
-    let words_snapshot = dictionary.words.lock().unwrap().clone();
+    let words_snapshot = dictionary.words.lock().clone();
     if words_snapshot.is_empty() {
         return transcription;
     }
 
-    let config_files = get_or_init_config_files(cc_rules_path);
+    let config_files = match get_or_init_config_files(cc_rules_path) {
+        Some(files) => files,
+        None => return transcription,
+    };
     let builder = BeiderMorseBuilder::new(config_files);
     let beider_morse = builder.build();
 
-    // TODO: Make user able to choose the languages for each word
     let langs = LanguageSet::from(vec!["french", "english"]);
 
     let encoded_dict = {
-        let mut cache = dictionary.encoded_cache.lock().unwrap();
+        let mut cache = dictionary.encoded_cache.lock();
         match cache.as_ref() {
             Some(cached) => cached.clone(),
             None => {

--- a/src-tauri/src/dictionary/dictionary.rs
+++ b/src-tauri/src/dictionary/dictionary.rs
@@ -1,7 +1,7 @@
+use crate::dictionary::types::Dictionary;
 use log::debug;
 use once_cell::sync::OnceCell;
 use rphonetic::{BeiderMorseBuilder, ConfigFiles, LanguageSet};
-use std::collections::HashMap;
 use std::path::PathBuf;
 use tauri::AppHandle;
 
@@ -12,33 +12,50 @@ use tauri::AppHandle;
 /// leaves the cell empty and the next call retries.
 static CC_RULES_PATH: OnceCell<PathBuf> = OnceCell::new();
 
+static CONFIG_FILES: OnceCell<ConfigFiles> = OnceCell::new();
+
+fn get_or_init_config_files(cc_rules_path: &PathBuf) -> &'static ConfigFiles {
+    CONFIG_FILES.get_or_init(|| {
+        ConfigFiles::new(cc_rules_path).expect("Failed to load BeiderMorse config files")
+    })
+}
+
 /**
  * Use phonetic algorithm to fix the transcription
  */
 pub fn fix_transcription_with_dictionary(
     transcription: String,
-    dictionary: &HashMap<String, Vec<String>>,
+    dictionary: &Dictionary,
     cc_rules_path: &PathBuf,
 ) -> String {
-    if dictionary.is_empty() {
+    let words_snapshot = dictionary.words.lock().unwrap().clone();
+    if words_snapshot.is_empty() {
         return transcription;
     }
 
-    let config_files = ConfigFiles::new(cc_rules_path).unwrap();
-    let builder = BeiderMorseBuilder::new(&config_files);
+    let config_files = get_or_init_config_files(cc_rules_path);
+    let builder = BeiderMorseBuilder::new(config_files);
     let beider_morse = builder.build();
 
     // TODO: Make user able to choose the languages for each word
     let langs = LanguageSet::from(vec!["french", "english"]);
 
-    // Prepare dictionary words to be encoded phonetically
-    let mut encoded_dict = Vec::new();
-    for word in dictionary.keys() {
-        let code = beider_morse.encode_with_languages(word, &langs);
-        encoded_dict.push((word, code));
-    }
+    let encoded_dict = {
+        let mut cache = dictionary.encoded_cache.lock().unwrap();
+        match cache.as_ref() {
+            Some(cached) => cached.clone(),
+            None => {
+                let mut encoded = Vec::with_capacity(words_snapshot.len());
+                for word in words_snapshot.keys() {
+                    let code = beider_morse.encode_with_languages(word, &langs);
+                    encoded.push((word.clone(), code));
+                }
+                *cache = Some(encoded.clone());
+                encoded
+            }
+        }
+    };
 
-    // Split transcription into words
     let mut corrected_transcription = transcription.clone();
     let words: Vec<&str> = transcription.split_whitespace().collect();
 
@@ -47,10 +64,6 @@ pub fn fix_transcription_with_dictionary(
         let candidate_codes: Vec<&str> = candidate.split('|').collect();
         for (dict_word, dict_code) in &encoded_dict {
             let dict_codes: Vec<&str> = dict_code.split('|').collect();
-            // println!(
-            //     "Dict word: {:?}, Dict code: {:?}, Candidate: {:?}",
-            //     dict_word, dict_code, candidate
-            // );
             if dict_codes.iter().any(|dc| candidate_codes.contains(dc)) {
                 corrected_transcription = corrected_transcription.replace(word, dict_word);
             }

--- a/src-tauri/src/dictionary/store.rs
+++ b/src-tauri/src/dictionary/store.rs
@@ -1,9 +1,10 @@
+use log::{info, trace};
 use std::collections::HashMap;
 use std::fs;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tauri_plugin_store::StoreExt;
 
-use crate::dictionary::DictionaryError;
+use crate::dictionary::{Dictionary, DictionaryError};
 
 fn find_word_case_insensitive(dictionary: &HashMap<String, Vec<String>>, word: &str) -> Option<()> {
     for key in dictionary.keys() {
@@ -33,7 +34,22 @@ pub fn save(app: &AppHandle, dictionary: &HashMap<String, Vec<String>>) -> Resul
             serde_json::to_value(languages).map_err(|e| e.to_string())?,
         );
     }
+
+    if let Some(state) = app.try_state::<Dictionary>() {
+        state.set(dictionary.clone());
+    }
+
     Ok(())
+}
+
+pub fn current(app: &AppHandle) -> Dictionary {
+    if let Some(state) = app.try_state::<Dictionary>() {
+        trace!("dictionary: loaded from memory state");
+        return state.inner().clone();
+    }
+    info!("dictionary: state not registered, falling back to disk");
+    let words = load(app).unwrap_or_default();
+    Dictionary::new(words)
 }
 
 pub fn migrate_and_load(

--- a/src-tauri/src/dictionary/types.rs
+++ b/src-tauri/src/dictionary/types.rs
@@ -5,7 +5,12 @@ pub type EncodedDict = Vec<(String, String)>;
 
 #[derive(Clone)]
 pub struct Dictionary {
+    /// Direct reads are fine (see `fix_transcription_with_dictionary`);
+    /// **never** mutate directly — always go through `Dictionary::set()`
+    /// so `encoded_cache` stays in sync with the words.
     pub words: Arc<Mutex<HashMap<String, Vec<String>>>>,
+    /// Populated lazily in `fix_transcription_with_dictionary`. Cleared
+    /// by `Dictionary::set()`. Do not mutate outside those two paths.
     pub encoded_cache: Arc<Mutex<Option<EncodedDict>>>,
 }
 
@@ -203,7 +208,10 @@ mod perf_bench {
                             serde_json::from_value(v.clone()).unwrap_or_default();
                         parsed.insert(k.clone(), langs);
                     }
-                    black_box(parsed);
+                    // Wrap in Dictionary::new to match the full production
+                    // path (fallback branch of `store::current()`).
+                    let wrapped = Dictionary::new(parsed);
+                    black_box(wrapped);
                 }
                 let store_path = start.elapsed();
 

--- a/src-tauri/src/dictionary/types.rs
+++ b/src-tauri/src/dictionary/types.rs
@@ -1,7 +1,5 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use parking_lot::Mutex;
+use std::{collections::HashMap, sync::Arc};
 
 pub type EncodedDict = Vec<(String, String)>;
 
@@ -19,8 +17,8 @@ impl Dictionary {
         }
     }
     pub fn set(&self, dictionary: HashMap<String, Vec<String>>) {
-        *self.words.lock().unwrap() = dictionary;
-        *self.encoded_cache.lock().unwrap() = None;
+        *self.words.lock() = dictionary;
+        *self.encoded_cache.lock() = None;
     }
 }
 
@@ -51,14 +49,14 @@ mod tests {
     #[test]
     fn new_starts_with_empty_cache() {
         let dict = Dictionary::new(HashMap::new());
-        assert!(dict.encoded_cache.lock().unwrap().is_none());
+        assert!(dict.encoded_cache.lock().is_none());
     }
 
     #[test]
     fn new_stores_words_unchanged() {
         let initial = words(&[("hello", &["english"]), ("bonjour", &["french"])]);
         let dict = Dictionary::new(initial.clone());
-        assert_eq!(*dict.words.lock().unwrap(), initial);
+        assert_eq!(*dict.words.lock(), initial);
     }
 
     #[test]
@@ -66,29 +64,29 @@ mod tests {
         let dict = Dictionary::new(words(&[("old", &["english"])]));
         let new_words = words(&[("new", &["french"])]);
         dict.set(new_words.clone());
-        assert_eq!(*dict.words.lock().unwrap(), new_words);
+        assert_eq!(*dict.words.lock(), new_words);
     }
 
     #[test]
     fn set_invalidates_populated_cache() {
         let dict = Dictionary::new(words(&[("hello", &["english"])]));
-        *dict.encoded_cache.lock().unwrap() =
+        *dict.encoded_cache.lock() =
             Some(vec![("hello".to_string(), "HL".to_string())]);
-        assert!(dict.encoded_cache.lock().unwrap().is_some());
+        assert!(dict.encoded_cache.lock().is_some());
 
         dict.set(words(&[("world", &["english"])]));
-        assert!(dict.encoded_cache.lock().unwrap().is_none());
+        assert!(dict.encoded_cache.lock().is_none());
     }
 
     #[test]
     fn set_to_same_words_still_invalidates_cache() {
         let initial = words(&[("hello", &["english"])]);
         let dict = Dictionary::new(initial.clone());
-        *dict.encoded_cache.lock().unwrap() =
+        *dict.encoded_cache.lock() =
             Some(vec![("hello".to_string(), "HL".to_string())]);
 
         dict.set(initial);
-        assert!(dict.encoded_cache.lock().unwrap().is_none());
+        assert!(dict.encoded_cache.lock().is_none());
     }
 
     #[test]
@@ -99,7 +97,7 @@ mod tests {
         let new_words = words(&[("shared", &["english"])]);
         dict.set(new_words.clone());
 
-        assert_eq!(*dict2.words.lock().unwrap(), new_words);
+        assert_eq!(*dict2.words.lock(), new_words);
     }
 
     #[test]
@@ -108,9 +106,9 @@ mod tests {
         let dict2 = dict.clone();
 
         let cached = vec![("a".to_string(), "A".to_string())];
-        *dict.encoded_cache.lock().unwrap() = Some(cached.clone());
+        *dict.encoded_cache.lock() = Some(cached.clone());
 
-        assert_eq!(*dict2.encoded_cache.lock().unwrap(), Some(cached));
+        assert_eq!(*dict2.encoded_cache.lock(), Some(cached));
     }
 
     #[test]
@@ -118,11 +116,11 @@ mod tests {
         let dict = Dictionary::new(words(&[("hello", &["english"])]));
         let dict2 = dict.clone();
 
-        *dict.encoded_cache.lock().unwrap() =
+        *dict.encoded_cache.lock() =
             Some(vec![("hello".to_string(), "HL".to_string())]);
-        assert!(dict2.encoded_cache.lock().unwrap().is_some());
+        assert!(dict2.encoded_cache.lock().is_some());
 
         dict.set(words(&[("world", &["english"])]));
-        assert!(dict2.encoded_cache.lock().unwrap().is_none());
+        assert!(dict2.encoded_cache.lock().is_none());
     }
 }

--- a/src-tauri/src/dictionary/types.rs
+++ b/src-tauri/src/dictionary/types.rs
@@ -3,17 +3,24 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-pub struct Dictionary(pub Arc<Mutex<HashMap<String, Vec<String>>>>);
+pub type EncodedDict = Vec<(String, String)>;
+
+#[derive(Clone)]
+pub struct Dictionary {
+    pub words: Arc<Mutex<HashMap<String, Vec<String>>>>,
+    pub encoded_cache: Arc<Mutex<Option<EncodedDict>>>,
+}
 
 impl Dictionary {
     pub fn new(dictionary: HashMap<String, Vec<String>>) -> Self {
-        Self(Arc::new(Mutex::new(dictionary)))
-    }
-    pub fn get(&self) -> HashMap<String, Vec<String>> {
-        self.0.lock().unwrap().clone()
+        Self {
+            words: Arc::new(Mutex::new(dictionary)),
+            encoded_cache: Arc::new(Mutex::new(None)),
+        }
     }
     pub fn set(&self, dictionary: HashMap<String, Vec<String>>) {
-        *self.0.lock().unwrap() = dictionary;
+        *self.words.lock().unwrap() = dictionary;
+        *self.encoded_cache.lock().unwrap() = None;
     }
 }
 
@@ -23,4 +30,99 @@ pub enum DictionaryError {
     InvalidWordFormat(String),
     #[error("Dictionary import must contain at least one valid word")]
     EmptyDictionary,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn words(pairs: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
+        pairs
+            .iter()
+            .map(|(k, langs)| {
+                (
+                    k.to_string(),
+                    langs.iter().map(|s| s.to_string()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn new_starts_with_empty_cache() {
+        let dict = Dictionary::new(HashMap::new());
+        assert!(dict.encoded_cache.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn new_stores_words_unchanged() {
+        let initial = words(&[("hello", &["english"]), ("bonjour", &["french"])]);
+        let dict = Dictionary::new(initial.clone());
+        assert_eq!(*dict.words.lock().unwrap(), initial);
+    }
+
+    #[test]
+    fn set_replaces_words() {
+        let dict = Dictionary::new(words(&[("old", &["english"])]));
+        let new_words = words(&[("new", &["french"])]);
+        dict.set(new_words.clone());
+        assert_eq!(*dict.words.lock().unwrap(), new_words);
+    }
+
+    #[test]
+    fn set_invalidates_populated_cache() {
+        let dict = Dictionary::new(words(&[("hello", &["english"])]));
+        *dict.encoded_cache.lock().unwrap() =
+            Some(vec![("hello".to_string(), "HL".to_string())]);
+        assert!(dict.encoded_cache.lock().unwrap().is_some());
+
+        dict.set(words(&[("world", &["english"])]));
+        assert!(dict.encoded_cache.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn set_to_same_words_still_invalidates_cache() {
+        let initial = words(&[("hello", &["english"])]);
+        let dict = Dictionary::new(initial.clone());
+        *dict.encoded_cache.lock().unwrap() =
+            Some(vec![("hello".to_string(), "HL".to_string())]);
+
+        dict.set(initial);
+        assert!(dict.encoded_cache.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn clone_shares_words_storage() {
+        let dict = Dictionary::new(HashMap::new());
+        let dict2 = dict.clone();
+
+        let new_words = words(&[("shared", &["english"])]);
+        dict.set(new_words.clone());
+
+        assert_eq!(*dict2.words.lock().unwrap(), new_words);
+    }
+
+    #[test]
+    fn clone_shares_cache_storage() {
+        let dict = Dictionary::new(HashMap::new());
+        let dict2 = dict.clone();
+
+        let cached = vec![("a".to_string(), "A".to_string())];
+        *dict.encoded_cache.lock().unwrap() = Some(cached.clone());
+
+        assert_eq!(*dict2.encoded_cache.lock().unwrap(), Some(cached));
+    }
+
+    #[test]
+    fn set_via_one_handle_invalidates_cache_on_clone() {
+        let dict = Dictionary::new(words(&[("hello", &["english"])]));
+        let dict2 = dict.clone();
+
+        *dict.encoded_cache.lock().unwrap() =
+            Some(vec![("hello".to_string(), "HL".to_string())]);
+        assert!(dict2.encoded_cache.lock().unwrap().is_some());
+
+        dict.set(words(&[("world", &["english"])]));
+        assert!(dict2.encoded_cache.lock().unwrap().is_none());
+    }
 }

--- a/src-tauri/src/dictionary/types.rs
+++ b/src-tauri/src/dictionary/types.rs
@@ -124,3 +124,111 @@ mod tests {
         assert!(dict2.encoded_cache.lock().is_none());
     }
 }
+
+#[cfg(test)]
+mod perf_bench {
+    use super::*;
+    use std::hint::black_box;
+    use std::time::Instant;
+
+    fn make_dictionary(n_words: usize) -> HashMap<String, Vec<String>> {
+        (0..n_words)
+            .map(|i| {
+                (
+                    format!("customword{}", i),
+                    vec!["english".to_string(), "french".to_string()],
+                )
+            })
+            .collect()
+    }
+
+    // Sweeps across realistic dictionary sizes: 1 / 10 / 100 / 1 000 / 5 000
+    // / 10 000 words.
+    //
+    // Baseline reflects production: `dictionary::store::load` iterates
+    // `store.entries()` from `tauri-plugin-store` (which keeps parsed
+    // `Value`s in memory) and calls `from_value<Vec<String>>` per entry.
+    // The state path (`current()`) is an O(1) Arc refcount bump — the
+    // HashMap is shared, not deep-cloned, regardless of word count.
+    //
+    // Hardening: `black_box` prevents DCE, 3 trials per size, steady-state
+    // (warm allocator). Iterations scale inverse to word count so the
+    // largest sizes still finish in seconds. Run with `--test-threads=1`
+    // for noise-free output:
+    //   cargo test --release --lib -- --ignored --nocapture --test-threads=1 perf_dictionary_disk_vs_state
+    #[test]
+    #[ignore]
+    fn perf_dictionary_disk_vs_state() {
+        const WARMUP: u32 = 2_000;
+        const TRIALS: u32 = 3;
+
+        println!("\n=== Dictionary load: store.entries+from_value  vs  state Arc-clone ===");
+        println!(
+            "{:>7} {:>10} {:>18} {:>18} {:>10} {:>10}",
+            "words", "json_B", "store+parse ns", "Arc clone ns", "speedup", "saved_ns"
+        );
+
+        for n_words in [1, 10, 100, 1000, 5000, 10000] {
+            let iters: u32 = match n_words {
+                n if n >= 5000 => 500,
+                n if n >= 1000 => 2_000,
+                _ => 50_000,
+            };
+
+            let words_map = make_dictionary(n_words);
+            let json = serde_json::to_string_pretty(&words_map).unwrap();
+            let stored_entries: HashMap<String, serde_json::Value> = words_map
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::to_value(v).unwrap()))
+                .collect();
+
+            for _ in 0..WARMUP {
+                let mut parsed = HashMap::new();
+                for (k, v) in stored_entries.iter() {
+                    let langs: Vec<String> =
+                        serde_json::from_value(v.clone()).unwrap_or_default();
+                    parsed.insert(k.clone(), langs);
+                }
+                black_box(parsed);
+            }
+
+            let dict = Dictionary::new(words_map);
+
+            for trial in 1..=TRIALS {
+                let start = Instant::now();
+                for _ in 0..iters {
+                    let mut parsed: HashMap<String, Vec<String>> = HashMap::new();
+                    for (k, v) in black_box(&stored_entries).iter() {
+                        let langs: Vec<String> =
+                            serde_json::from_value(v.clone()).unwrap_or_default();
+                        parsed.insert(k.clone(), langs);
+                    }
+                    black_box(parsed);
+                }
+                let store_path = start.elapsed();
+
+                let start = Instant::now();
+                for _ in 0..iters {
+                    let cloned = dict.clone();
+                    black_box(cloned);
+                }
+                let state_time = start.elapsed();
+
+                let store_ns = store_path.as_nanos() / iters as u128;
+                let state_ns = state_time.as_nanos() / iters as u128;
+                let speedup = store_ns as f64 / state_ns.max(1) as f64;
+
+                println!(
+                    "{:>4}#{} {:>10} {:>18} {:>18} {:>9.1}× {:>10}",
+                    n_words,
+                    trial,
+                    json.len(),
+                    store_ns,
+                    state_ns,
+                    speedup,
+                    store_ns.saturating_sub(state_ns)
+                );
+            }
+        }
+    }
+}

--- a/src-tauri/src/http_api/server.rs
+++ b/src-tauri/src/http_api/server.rs
@@ -97,7 +97,7 @@ async fn transcribe_handler(
                             Ok(raw_text) => {
                                 let text = match get_cc_rules_path(&app) {
                                     Ok(cc_rules_path) => {
-                                        let dictionary = app.state::<Dictionary>().get();
+                                        let dictionary = app.state::<Dictionary>();
                                         fix_transcription_with_dictionary(
                                             raw_text,
                                             &dictionary,


### PR DESCRIPTION
  ## Summary

  `settings::load_settings` (30+ call sites), `load_llm_connect_settings` (8 sites), and `formatting_rules::load` (2 hot-path sites) were doing `fs::read_to_string` + `serde_json::from_str` on every call,
  including per-recording and per-streaming-tick.

  All four config stores are now cached in Tauri state:
  - `SettingsState`, `FormattingState`, `LLMConnectState` — new `Arc<parking_lot::Mutex<T>>` wrappers registered at startup.
  - `Dictionary` (from this PR's original commit) — now auto-synced from `dictionary::store::save` via `try_state`, preserving the `encoded_cache` invalidation invariant.

  Every `save()` auto-syncs the in-memory state. Every accessor falls back to disk if state is not registered (pre-`manage`, tests, edge cases), logged at `info`. Original scope (phonetic encoding + BeiderMorse
   `ConfigFiles`) is preserved and hardened: `parking_lot::Mutex` on `Dictionary`, `&Path` instead of `&PathBuf`, graceful `warn!` fallback instead of `.expect()` panic if `ConfigFiles` init fails.

  All 136 lib tests pass.

  ## Description

  Cache `AppSettings`, `FormattingSettings`, `LLMConnectSettings`, and `Dictionary` in memory with an automatic disk fallback, invalidated on every `save()`.

  ## Type of change

  - [x] Enhancement of an existing feature
  - [x] Refactor / code cleanup

  ## Tested on

  - [ ] Windows
  - [x] Linux
  - [ ] macOS

  ## Checklist

  - [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
  - [x] My PR addresses **one single concern**
  - [x] I tested my changes manually and they work as expected
  - [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
  - [x] I checked for SonarQube issues on the draft PR