### PR TITLE
fix(logs): use local timezone for log timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ See [CHANGELOG.md](./CHANGELOG.md).
 - [ ] feat(shortcuts) : do not display LLM Connect shortcut if not enabled
 - [ ] feat(shortcuts): Add a shortcut to toggle Voice Mode on/off https://github.com/Kieirra/murmure/issues/279
 - [ ] fix(typing): Direct mode too fast for some apps https://github.com/Kieirra/murmure/issues/285
-- [ ] fix: Log time not displayed in the correct timezone
+- [x] fix: Log time not displayed in the correct timezone
 - [ ] feat(rules): Allow adding a custom name for personal formatting rules
 
 ### Backlog

--- a/README.md
+++ b/README.md
@@ -194,11 +194,10 @@ See [CHANGELOG.md](./CHANGELOG.md).
 - [x] fix(tray): macOS tray icon now adapts to light/dark mode using a template image (thanks @fwehrling) https://github.com/Kieirra/murmure/pull/312
 - [x] perf(llm): skip Ollama warmup when model is already loaded (thanks @BorisLord) https://github.com/Kieirra/murmure/pull/324
 - [x] fix(ui): use bundled asset for sidebar logo to avoid subroute 404 (thanks @BorisLord) https://github.com/Kieirra/murmure/pull/323
-- [ ] feat(overlay): Allow dragging the overlay to change its position https://github.com/Kieirra/murmure/issues/64
+- [x] fix: Log time not displayed in the correct timezone
 - [ ] feat(shortcuts) : do not display LLM Connect shortcut if not enabled
 - [ ] feat(shortcuts): Add a shortcut to toggle Voice Mode on/off https://github.com/Kieirra/murmure/issues/279
 - [ ] fix(typing): Direct mode too fast for some apps https://github.com/Kieirra/murmure/issues/285
-- [x] fix: Log time not displayed in the correct timezone
 - [ ] feat(rules): Allow adding a custom name for personal formatting rules
 
 ### Backlog

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ See [CHANGELOG.md](./CHANGELOG.md).
 - [x] fix(voice-mode): Wake word not detected when spoken mid-sentence without a pause
 - [x] feat(linux): Native Wayland support via xdg-desktop-portal GlobalShortcuts (experimental, KDE recommended)
 - [x] fix(tray): macOS tray icon now adapts to light/dark mode using a template image (thanks @fwehrling) https://github.com/Kieirra/murmure/pull/312
+- [x] perf(llm): skip Ollama warmup when model is already loaded (thanks @BorisLord) https://github.com/Kieirra/murmure/pull/324
+- [x] fix(ui): use bundled asset for sidebar logo to avoid subroute 404 (thanks @BorisLord) https://github.com/Kieirra/murmure/pull/323
 - [ ] feat(overlay): Allow dragging the overlay to change its position https://github.com/Kieirra/murmure/issues/64
 - [ ] feat(shortcuts) : do not display LLM Connect shortcut if not enabled
 - [ ] feat(shortcuts): Add a shortcut to toggle Voice Mode on/off https://github.com/Kieirra/murmure/issues/279

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,7 +39,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tauri::{DeviceEventFilter, Listener, Manager};
 use tauri_plugin_autostart::ManagerExt;
-use tauri_plugin_log::{Target, TargetKind};
+use tauri_plugin_log::{Target, TargetKind, TimezoneStrategy};
 use wake_word::types::WakeWordState;
 
 fn show_main_window(app: &tauri::AppHandle) {
@@ -73,6 +73,7 @@ pub fn run() {
                     Target::new(TargetKind::Webview),
                     Target::new(TargetKind::LogDir { file_name: None }),
                 ])
+                .timezone_strategy(TimezoneStrategy::UseLocal)
                 .max_file_size(1024 * 1024) // 1 MB, rotation
                 .level(log::LevelFilter::Trace)
                 .level_for("ort", log::LevelFilter::Warn)


### PR DESCRIPTION
## Description

Configure `tauri-plugin-log` with `TimezoneStrategy::UseLocal` so log timestamps are written in the user's local timezone instead of UTC, making it easier to correlate log entries with in-app actions.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other:

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [x] I checked for SonarQube issues on the draft PR