### PR TITLE
docs(wayland): readability pass, fix obsolete quick fixes, and slim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,6 @@ Learn more on the [official website](https://murmure.al1x-ai.com/) | [Documentat
 
 ![demo](public/murmure-screenshot-beautiful.png)
 
-## Table of Contents
-
-- [Features](#features)
-- [Usage](#usage)
-- [Installation](#installation)
-    - [Windows (Official)](#windows-official)
-    - [Linux (Official)](#linux-official)
-    - [MacOS (Official)](#macos-official)
-    - [MacOS - Intel (Official)](#macos---intel-official)
-- [CLI Import (1.8.0)](#cli-import-180)
-- [Changelog](#changelog)
-- [🗺️ Roadmap](#️-roadmap)
-- [Contributing](#contributing)
-- [Privacy Policy](#privacy-policy)
-- [Sponsors](#sponsors)
-- [Support Development](#support-development)
-- [License](#license)
-- [Acknowledgments](#acknowledgments)
-
 ## Features
 
 - **Privacy First**: All processing happens locally on your device. No data ever leaves your computer.
@@ -76,6 +57,9 @@ Multiple installation methods are available:
 
 ### Linux (Official)
 
+> [!NOTE]
+> **Wayland**: Two shortcut modes are available. KDE Plasma 6, Hyprland, and Sway use the `xdg-desktop-portal` GlobalShortcuts portal with no manual setup. GNOME defaults to CLI mode: you must configure a custom OS shortcut before using Murmure, and Push-to-talk is not available. See the [Linux installation guide](https://docs.murmure.app/getting-started/linux/) and the [shortcut configuration guide](https://docs.murmure.app/configure-shortcuts-on-linux/).
+
 Multiple installation methods are available:
 
 - Quick install via terminal (Debian-based distributions):
@@ -92,9 +76,6 @@ Multiple installation methods are available:
     1. Download `Murmure_amd64.AppImage` from the [release](https://github.com/Kieirra/murmure/releases) page.
     2. Make it executable: `chmod +x Murmure_amd64.AppImage`
     3. Run the AppImage.
-
-> [!NOTE]
-> **Wayland (1.9.0+)**: Wayland support starts from version **1.9.0**. Earlier versions do not work on Wayland. Two shortcut modes are available: the `xdg-desktop-portal` GlobalShortcuts portal (recommended for KDE Plasma 6, Hyprland, Sway), or CLI mode where you bind OS-level custom shortcuts to `murmure` commands directly (recommended for GNOME). See the [Linux installation guide](https://docs.murmure.app/getting-started/linux/) and the [shortcut configuration guide](https://docs.murmure.app/configure-shortcuts-on-linux/) for setup details.
 
 ### MacOS (Official)
 
@@ -123,51 +104,11 @@ it should work. It's a bit painful but you will not do it again with the next ve
 3. Murmure should ask for permissions to access your microphone and accessibility.
 4. Restart Murmure for the permissions to take effect.
 
-> [!IMPORTANT]
-> **Updating Murmure on macOS from 1.6.0:** If you experience issues with Murmure and the shortcuts are not working, please do this exactly in this order, (and "Remove" means not only un-toggling but really removing completely Murmure from the list) :
-
-1. Remove Murmure from System Settings → Privacy & Security → Accessibility.
-2. Remove Murmure from System Settings → Privacy & Security → Input monitoring.
-3. Install the last version
-4. Launch Murmure.
-5. Re-grant the Accessibility
-6. Re-grant the Input monitoring permission
-7. Restart Murmure.
-
-it should work. It's a bit painful but you will not do it again with the next version, it's because 1.6.0 have the same name but is not detected as the same application... so macos is lost.
+The same upgrade note from 1.6.0 applies. See the MacOS section above.
 
 ## CLI Import (1.8.0)
 
-> [!NOTE]
-> This feature is available starting from version **1.8.0**.
-
-Murmure supports importing a `.murmure` configuration file via the command line, useful for sysadmin mass deployment or sharing settings across machines.
-
-**Linux:**
-
-```sh
-murmure import config.murmure
-```
-
-**macOS:**
-
-```sh
-/Applications/murmure.app/Contents/MacOS/murmure import config.murmure
-```
-
-**Windows:**
-
-```powershell
-murmure.exe import config.murmure
-```
-
-You can also specify an import strategy (`replace` by default, or `merge` to keep existing settings and add new ones):
-
-```sh
-murmure import config.murmure --strategy merge
-```
-
-For more details, run `murmure import --help`.
+Murmure supports importing a `.murmure` configuration file via the command line (`murmure import config.murmure`), useful for mass deployment or sharing settings across machines. A `--strategy merge` option is available to keep existing settings. See the [CLI documentation](https://docs.murmure.app/features/cli/) for details.
 
 ## Changelog
 

--- a/docs/configure-shortcuts-on-linux.fr.md
+++ b/docs/configure-shortcuts-on-linux.fr.md
@@ -120,7 +120,7 @@ Si vous avez besoin de XWayland (par exemple un compositeur plus ancien sans sup
 GDK_BACKEND=x11 murmure
 ```
 
-Il s'agit d'une variable GTK standard. Murmure ne la définit plus automatiquement depuis la version 1.10.0. En mode XWayland, les raccourcis globaux ne se déclenchent que lorsque la fenêtre Murmure a le focus.
+Il s'agit d'une variable GTK standard. Murmure ne la définit plus automatiquement. En mode XWayland, les raccourcis globaux ne se déclenchent que lorsque la fenêtre Murmure a le focus.
 
 ### Les raccourcis XDG Portal fonctionnent sur Hyprland mais pas après un redémarrage
 

--- a/docs/configure-shortcuts-on-linux.md
+++ b/docs/configure-shortcuts-on-linux.md
@@ -122,7 +122,7 @@ If you need XWayland for any reason (for example an older compositor with no por
 GDK_BACKEND=x11 murmure
 ```
 
-This is a GTK-standard variable. Murmure no longer sets it automatically since version 1.10.0. In XWayland mode, global shortcuts only fire when the Murmure window has focus.
+This is a GTK-standard variable. Murmure no longer sets it automatically. In XWayland mode, global shortcuts only fire when the Murmure window has focus.
 
 ### XDG Portal shortcuts work on Hyprland but not after a reboot
 

--- a/docs/getting-started/first-steps.fr.md
+++ b/docs/getting-started/first-steps.fr.md
@@ -13,6 +13,9 @@ Apres avoir installe Murmure, voici comment en tirer le meilleur parti.
 !!! tip
     La premiere transcription apres le lancement est un peu plus lente car le modele IA doit se charger. Les suivantes sont plus rapides.
 
+!!! note "Utilisateurs Linux Wayland"
+    Sur GNOME Wayland, `Ctrl+Espace` ne fonctionne pas par defaut. Murmure passe en mode CLI sur GNOME, ce qui signifie que vous devez configurer un raccourci personnalise au niveau du systeme avant cette etape. Voir [Configurer les raccourcis sous Linux](../configure-shortcuts-on-linux.fr.md) pour les instructions pas-a-pas.
+
 ## Choisir le mode d'enregistrement
 
 ![Parametres systeme](../assets/settings-system.png)
@@ -47,11 +50,12 @@ Le raccourci par defaut `Ctrl+Espace` peut entrer en conflit avec d'autres appli
 
 **Raccourcis recommandes par OS :**
 
-| OS          | Recommande                                                                 | A eviter                                       |
-| ----------- | -------------------------------------------------------------------------- | ---------------------------------------------- |
-| Windows     | `Ctrl+Espace`, `Ctrl+Alt+M`, `F2`, bouton lateral/supplementaire de souris | Combinaisons AltGr (interprete comme Ctrl+Alt) |
-| macOS       | `Ctrl+Option+M`, `F2`, `F3`, bouton lateral/supplementaire de souris       | Espace ou chiffres                             |
-| Linux (X11) | `Ctrl+Espace`, `F2`, bouton lateral/supplementaire de souris               | -                                              |
+| OS                  | Recommande                                                                 | A eviter                                       |
+| ------------------- | -------------------------------------------------------------------------- | ---------------------------------------------- |
+| Windows             | `Ctrl+Espace`, `Ctrl+Alt+M`, `F2`, bouton lateral/supplementaire de souris | Combinaisons AltGr (interprete comme Ctrl+Alt) |
+| macOS               | `Ctrl+Option+M`, `F2`, `F3`, bouton lateral/supplementaire de souris       | Espace ou chiffres                             |
+| Linux (X11)         | `Ctrl+Espace`, `F2`, bouton lateral/supplementaire de souris               | -                                              |
+| Linux (Wayland)     | Configurer un raccourci OS appelant `murmure --transcription` | Voir [Configurer les raccourcis sous Linux](../configure-shortcuts-on-linux.fr.md) |
 
 ## Modes d'insertion du texte
 

--- a/docs/getting-started/first-steps.md
+++ b/docs/getting-started/first-steps.md
@@ -13,6 +13,9 @@ After installing Murmure, here's how to get the most out of it.
 !!! tip
     The first transcription after launching Murmure is slightly slower because the AI model needs to warm up. Subsequent transcriptions are faster.
 
+!!! note "Linux Wayland users"
+    On GNOME Wayland, `Ctrl+Space` does not work out of the box. Murmure defaults to CLI mode on GNOME, which means you must configure a custom OS-level shortcut before this step. See [Configure shortcuts on Linux](../configure-shortcuts-on-linux.md) for step-by-step instructions.
+
 ## Choose Your Recording Mode
 
 ![System Settings](../assets/settings-system.png)
@@ -47,11 +50,12 @@ The default shortcut `Ctrl+Space` may conflict with other apps. To change it:
 
 **Recommended shortcuts by OS:**
 
-| OS          | Recommended                                               | Avoid                                  |
-| ----------- | --------------------------------------------------------- | -------------------------------------- |
-| Windows     | `Ctrl+Space`, `Ctrl+Alt+M`, `F2`, side/extra mouse button | AltGr combos (interpreted as Ctrl+Alt) |
-| macOS       | `Ctrl+Option+M`, `F2`, `F3`, side/extra mouse button      | Anything with Space or numbers         |
-| Linux (X11) | `Ctrl+Space`, `F2`, side/extra mouse button               | -                                      |
+| OS               | Recommended                                               | Avoid                                  |
+| ---------------- | --------------------------------------------------------- | -------------------------------------- |
+| Windows          | `Ctrl+Space`, `Ctrl+Alt+M`, `F2`, side/extra mouse button | AltGr combos (interpreted as Ctrl+Alt) |
+| macOS            | `Ctrl+Option+M`, `F2`, `F3`, side/extra mouse button      | Anything with Space or numbers         |
+| Linux (X11)      | `Ctrl+Space`, `F2`, side/extra mouse button               | -                                      |
+| Linux (Wayland)  | Configure a custom OS shortcut calling `murmure --transcription` | See [Configure shortcuts on Linux](../configure-shortcuts-on-linux.md) |
 
 ## Text Insertion Modes
 

--- a/docs/getting-started/linux.fr.md
+++ b/docs/getting-started/linux.fr.md
@@ -2,10 +2,10 @@
 
 !!! important "Pre-requis"
     - **Les sessions X11** sont entierement supportees.
-    - **Les sessions Wayland** sont supportees en mode experimental.
-        - **KDE Plasma 5.27+/6.x Wayland** est le bureau Wayland recommande pour la meilleure experience.
-        - **GNOME 48+ Wayland** est supporte mais encore immature : les raccourcis peuvent presenter une latence variable (dizaines a centaines de ms) et des inconsistances ponctuelles.
-        - **Sway, Hyprland et autres compositeurs Wayland** peuvent fonctionner selon que le compositeur integre un backend portal GlobalShortcuts compatible avec `xdg-desktop-portal`.
+    - **Les sessions Wayland** sont supportees. Deux modes de raccourcis sont disponibles selon votre environnement de bureau :
+        - **KDE Plasma 5.27+/6.x, Hyprland, Sway** : les raccourcis globaux fonctionnent via XDG Portal sans configuration manuelle.
+        - **GNOME 48+ Wayland** : Murmure passe en mode CLI par defaut. Vous devez configurer un raccourci OS manuellement avant d'utiliser Murmure. Le Push-to-talk n'est pas disponible en mode CLI (uniquement le mode toggle). Voir [Configurer les raccourcis sous Linux](../configure-shortcuts-on-linux.fr.md).
+        - **Autres compositeurs** : peuvent fonctionner si le compositeur supporte le backend portal GlobalShortcuts de `xdg-desktop-portal`.
 
 ## Methodes d'installation
 
@@ -51,8 +51,8 @@ Murmure tourne nativement sous Wayland. Les raccourcis globaux sont gérés par 
 
 | Mode | Description |
 | ---- | ----------- |
-| **XDG Portal** | Murmure enregistre les raccourcis via l'interface GlobalShortcuts de `xdg-desktop-portal`. Fonctionne de façon fiable sur KDE Plasma 6, Hyprland et Sway. |
-| **CLI** | Murmure n'enregistre aucun raccourci. Vous configurez des Custom Shortcuts OS qui appellent le binaire `murmure`. Par défaut sur GNOME car l'implémentation portal de Mutter est instable. |
+| **XDG Portal** | Murmure enregistre les raccourcis via l'interface GlobalShortcuts de `xdg-desktop-portal`. Fonctionne de façon fiable sur KDE Plasma 6, Hyprland et Sway. Push-to-talk et mode toggle sont disponibles. |
+| **CLI** | Murmure n'enregistre aucun raccourci. Vous configurez des Custom Shortcuts OS qui appellent le binaire `murmure`. Par défaut sur GNOME car l'implémentation portal de Mutter est instable. Seul le mode toggle est disponible (les raccourcis OS se déclenchent à l'appui, pas au relâchement). |
 
 ### Defaults par bureau
 

--- a/docs/getting-started/linux.md
+++ b/docs/getting-started/linux.md
@@ -2,10 +2,10 @@
 
 !!! important "Requirements"
     - **X11 sessions** are fully supported.
-    - **Wayland sessions** are supported in experimental mode.
-        - **KDE Plasma 5.27+/6.x Wayland** is the recommended Wayland desktop for the smoothest experience.
-        - **GNOME 48+ Wayland** is supported but currently immature: shortcuts may exhibit latency (tens to hundreds of ms) and occasional inconsistencies.
-        - **Sway, Hyprland, and other Wayland compositors** may work depending on whether the compositor supports the `xdg-desktop-portal` GlobalShortcuts portal backend.
+    - **Wayland sessions** are supported. Two shortcut modes are available depending on your desktop environment:
+        - **KDE Plasma 5.27+/6.x, Hyprland, Sway**: global shortcuts work via XDG Portal with no manual configuration.
+        - **GNOME 48+ Wayland**: Murmure defaults to CLI mode. You must configure a custom OS shortcut manually before using Murmure. Push-to-talk is not available in CLI mode (only toggle mode). See [Configure shortcuts on Linux](../configure-shortcuts-on-linux.md).
+        - **Other compositors**: may work if the compositor supports the `xdg-desktop-portal` GlobalShortcuts portal backend.
 
 ## Installation Methods
 
@@ -53,8 +53,8 @@ Murmure runs natively on Wayland. Global shortcuts are handled by one of two mod
 
 | Mode | Description |
 | ---- | ----------- |
-| **XDG Portal** | Murmure registers shortcuts through the `xdg-desktop-portal` GlobalShortcuts interface. Works reliably on KDE Plasma 6, Hyprland, and Sway. |
-| **CLI** | Murmure registers no shortcuts. You bind OS-level custom shortcuts that call the `murmure` binary. Default on GNOME because Mutter's portal implementation is unreliable. |
+| **XDG Portal** | Murmure registers shortcuts through the `xdg-desktop-portal` GlobalShortcuts interface. Works reliably on KDE Plasma 6, Hyprland, and Sway. Both Push-to-talk and toggle mode are available. |
+| **CLI** | Murmure registers no shortcuts. You bind OS-level custom shortcuts that call the `murmure` binary. Default on GNOME because Mutter's portal implementation is unreliable. Only toggle mode is available (OS shortcuts fire on key press only, not on release). |
 
 ### Desktop defaults
 

--- a/docs/index.fr.md
+++ b/docs/index.fr.md
@@ -18,7 +18,7 @@ Bulgare, croate, tcheque, danois, neerlandais, anglais, estonien, finnois, franc
 
 ## Liens rapides
 
-- [Demarrage rapide](getting-started/windows.md) - Installer Murmure sur votre OS
+- Installation : [Windows](getting-started/windows.md) / [macOS](getting-started/macos.md) / [Linux](getting-started/linux.md)
 - [Fonctionnalites](features/transcription.md) - Decouvrir toutes les fonctionnalites
 - [Depannage](troubleshooting/index.md) - Resoudre les problemes courants
 - [FAQ](faq.md) - Questions frequentes

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Bulgarian, Croatian, Czech, Danish, Dutch, English, Estonian, Finnish, French, G
 
 ## Quick Links
 
-- [Getting Started](getting-started/windows.md) - Install Murmure on your OS
+- Install Murmure: [Windows](getting-started/windows.md) / [macOS](getting-started/macos.md) / [Linux](getting-started/linux.md)
 - [Features](features/transcription.md) - Learn about all features
 - [Troubleshooting](troubleshooting/index.md) - Fix common issues
 - [FAQ](faq.md) - Frequently asked questions

--- a/docs/troubleshooting/index.fr.md
+++ b/docs/troubleshooting/index.fr.md
@@ -16,7 +16,7 @@ Solutions aux problemes les plus courants, basees sur les retours utilisateurs.
 | Mauvaise langue               | Verifier la qualite du micro, reduire le bruit                                         |
 | Texte pas colle               | Passer en mode Direct (Parametres > Systeme)                                           |
 | Conflit raccourci (macOS)     | Changer pour Ctrl+Option+M                                                             |
-| Raccourci inactif (Linux)     | Passer en session X11                                                                  |
+| Raccourci inactif (Linux)     | Voir [Configurer les raccourcis sous Linux](../configure-shortcuts-on-linux.fr.md)     |
 | Erreur MSVCP140.dll (Windows) | Installer [Visual C++ Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe) |
 | Erreur Ollama 500             | Utiliser un modele plus petit (qwen3.5:4b)                                             |
 | Parametres corrompus          | Supprimer settings.json et redemarrer                                                  |

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -16,7 +16,7 @@ Find solutions to the most common issues. These pages are based on real user rep
 | Wrong language               | Check microphone quality, reduce noise                                               |
 | Text not pasted              | Switch to Direct mode (Settings > System)                                            |
 | Shortcut conflict (macOS)    | Change shortcut to Ctrl+Option+M                                                     |
-| Shortcut not working (Linux) | Switch to X11 session                                                                |
+| Shortcut not working (Linux) | See [Configure shortcuts on Linux](../configure-shortcuts-on-linux.md)               |
 | MSVCP140.dll error (Windows) | Install [Visual C++ Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe) |
 | Ollama 500 error             | Use a smaller model (qwen3.5:4b)                                                     |
 | Settings corrupted           | Delete settings.json and restart                                                     |


### PR DESCRIPTION
## Summary

- **P1 (troubleshooting)**: replace "Switch to X11 session" quick fix with a link to the Linux shortcut configuration guide. X11 fallback is no longer the recommended path since Wayland is natively supported.
- **P2 (first-steps)**: add a GNOME Wayland callout in the "Your First Transcription" section (Ctrl+Space does not work out of the box on GNOME Wayland); add a Linux (Wayland) row to the recommended shortcuts table.
- **P3 (linux)**: document the Push-to-talk limitation in CLI mode in both the requirements preamble and the Wayland mode table (confirmed in `src-tauri/src/shortcuts/cli_dispatch.rs` line 14).
- **P4 (linux, configure-shortcuts-on-linux)**: replace the vague "experimental mode" framing with concrete per-DE facts. GNOME defaults to CLI mode with manual shortcut setup required and push-to-talk unavailable. KDE, Hyprland, and Sway work via XDG Portal with no manual setup.
- **P5 (README)**: move the Wayland note to the top of the Linux section, before the installation methods. Updated to reflect concrete DE behavior instead of a version number.
- **P6 (configure-shortcuts-on-linux)**: remove the "since version 1.10.0" reference. That version tag does not exist in the repository (`git tag` confirms the latest is `Enhanced` at 1.8.99). The factual statement (Murmure no longer sets GDK_BACKEND automatically) is kept.
- **P7 (index)**: replace the generic "Getting Started" link pointing to `windows.md` with three explicit OS links (Windows / macOS / Linux).
- **README slim**: remove manual Table of Contents (GitHub renders one automatically), collapse duplicate macOS 1.6.0 upgrade instructions, condense CLI Import section to one paragraph.

Both EN and FR versions updated for all documentation changes.

## What was NOT done (and why)

- The "since 1.9.0" reference in `troubleshooting/shortcuts.md` (cooldown mechanism) was not changed: 1.9.0 appears in the roadmap with all tasks checked and is a plausible future release. Changing it would require confirmation from the release process.
- The `docs/faq.md` mention of "Wayland support in 1.9.0" was not changed for the same reason.
- The README roadmap section was not touched: its content reflects planned work and is outside the scope of this readability pass.

## Test plan

- [ ] `mkdocs build` completes without errors (verified locally)
- [ ] Open `troubleshooting/index.md`: "Shortcut not working (Linux)" now links to configure-shortcuts-on-linux
- [ ] Open `getting-started/first-steps.md`: GNOME Wayland callout present after the first transcription tip; Linux (Wayland) row in shortcuts table
- [ ] Open `getting-started/linux.md`: requirements preamble lists GNOME CLI limitation with push-to-talk note; Wayland mode table has push-to-talk column
- [ ] Open `configure-shortcuts-on-linux.md`: "since version 1.10.0" no longer present
- [ ] Open `docs/index.md`: Quick Links shows three OS install links
- [ ] Open README: Wayland note appears before installation methods in the Linux section; macOS Intel section has a one-line cross-reference instead of duplicate instructions; CLI Import is one paragraph; no manual TOC