### PR TITLE
fix(overlay): make recording overlay non-focusable on Linux

### DIFF
--- a/src-tauri/src/audio/audio.rs
+++ b/src-tauri/src/audio/audio.rs
@@ -230,19 +230,20 @@ fn reset_recording_ui_delayed(app: &AppHandle, delay_ms: u64) {
 }
 
 pub fn write_transcription(app: &AppHandle, transcription: &str) -> Result<()> {
-    // Linux+Wayland only: hide BEFORE paste so KWin/Mutter hand
-    // keyboard focus back to the target app before Ctrl+V fires.
-    // The 400 ms settle in `clipboard::paste_with_delay` relies on
-    // this order via `overlay::millis_since_last_overlay_hide`.
+    // Linux: hide BEFORE paste so the WM (KWin/Mutter on Wayland, any X11 WM)
+    // hands keyboard focus back to the target app before Ctrl+V fires.
+    // On X11 the first overlay creation can steal focus from the target field
+    // despite `.focused(false)` (no `_NET_WM_USER_TIME` hint at 0), so the
+    // synthetic Ctrl+V would land on the overlay webview instead.
+    // The 400 ms settle in `clipboard::paste_with_delay` relies on this order
+    // via `overlay::millis_since_last_overlay_hide`.
     // Other platforms keep the original timing (hide after paste in
     // `reset_recording_ui*`).
     #[cfg(target_os = "linux")]
     {
-        if crate::utils::platform::is_wayland_session() {
-            let s = crate::settings::load_settings(app);
-            if s.overlay_mode.as_str() == "recording" {
-                overlay::hide_recording_overlay(app);
-            }
+        let s = crate::settings::load_settings(app);
+        if s.overlay_mode.as_str() == "recording" {
+            overlay::hide_recording_overlay(app);
         }
     }
 

--- a/src-tauri/src/audio/audio.rs
+++ b/src-tauri/src/audio/audio.rs
@@ -230,20 +230,19 @@ fn reset_recording_ui_delayed(app: &AppHandle, delay_ms: u64) {
 }
 
 pub fn write_transcription(app: &AppHandle, transcription: &str) -> Result<()> {
-    // Linux: hide BEFORE paste so the WM (KWin/Mutter on Wayland, any X11 WM)
-    // hands keyboard focus back to the target app before Ctrl+V fires.
-    // On X11 the first overlay creation can steal focus from the target field
-    // despite `.focused(false)` (no `_NET_WM_USER_TIME` hint at 0), so the
-    // synthetic Ctrl+V would land on the overlay webview instead.
-    // The 400 ms settle in `clipboard::paste_with_delay` relies on this order
-    // via `overlay::millis_since_last_overlay_hide`.
+    // Linux+Wayland only: hide BEFORE paste so KWin/Mutter hand
+    // keyboard focus back to the target app before Ctrl+V fires.
+    // The 400 ms settle in `clipboard::paste_with_delay` relies on
+    // this order via `overlay::millis_since_last_overlay_hide`.
     // Other platforms keep the original timing (hide after paste in
     // `reset_recording_ui*`).
     #[cfg(target_os = "linux")]
     {
-        let s = crate::settings::load_settings(app);
-        if s.overlay_mode.as_str() == "recording" {
-            overlay::hide_recording_overlay(app);
+        if crate::utils::platform::is_wayland_session() {
+            let s = crate::settings::load_settings(app);
+            if s.overlay_mode.as_str() == "recording" {
+                overlay::hide_recording_overlay(app);
+            }
         }
     }
 

--- a/src-tauri/src/overlay/overlay.rs
+++ b/src-tauri/src/overlay/overlay.rs
@@ -172,6 +172,7 @@ pub fn create_recording_overlay(app_handle: &AppHandle) {
     .skip_taskbar(true)
     .transparent(true)
     .focused(false)
+    .focusable(false)
     .visible(false)
     .build();
     match res {

--- a/src-tauri/src/overlay/overlay.rs
+++ b/src-tauri/src/overlay/overlay.rs
@@ -171,7 +171,6 @@ pub fn create_recording_overlay(app_handle: &AppHandle) {
     .always_on_top(true)
     .skip_taskbar(true)
     .transparent(true)
-    .focused(false)
     .focusable(false)
     .visible(false)
     .build();


### PR DESCRIPTION
## Description

The recording overlay window steals keyboard focus from the target field on Linux X11 on the first push-to-talk after launch. The focus stays on the overlay for the entire duration of that first PTT, so the subsequent Ctrl+V lands on the overlay webview instead of the target and nothing gets pasted.

This PR marks the overlay as non-focusable so the WM never grants it keyboard focus.

## Root cause

The overlay is built with `.focused(false)`, which tao translates to GTK `accept_focus(false)` but then resets to `accept_focus(true)` after the first `draw` signal. Combined with a missing `_NET_WM_USER_TIME` hint (the window is created from a global shortcut handler outside the GTK app), X11 WMs grant focus to the new always-on-top window.

## Fix

`.focusable(false)` on the `WebviewWindowBuilder`. In tao's Linux backend this both sets `accept_focus(false)` and skips the post-draw restoration, so the WM never grants focus to the overlay. The overlay is purely visual (already `set_ignore_cursor_events(true)`), so the change has no functional cost.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other:

## Tested on

- [ ] Windows
- [x] Linux (X11)
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [x] I checked for SonarQube issues on the draft PR