### PR TITLE
fix(shortcuts): restore immediate stop-on-release for push-to-talk

### DIFF
--- a/src-tauri/src/shortcuts/shortcuts.rs
+++ b/src-tauri/src/shortcuts/shortcuts.rs
@@ -160,12 +160,6 @@ fn pushtotalk_recording_action<F>(
 {
     let mut recording_source = recording_state().source.lock();
 
-    // Push-to-talk mirrors the physical key state 1:1: start on press, stop on
-    // release. X11 auto-repeat (synthetic Release+Press bursts) is already
-    // filtered upstream in platform_linux, and Windows/macOS poll the real key
-    // state, so a Release here is always a genuine physical release. A cooldown
-    // would swallow legitimate quick taps and make push-to-talk behave like
-    // toggle, so none is applied (unlike ToggleToTalk).
     match event_type {
         KeyEventType::Pressed => {
             if *recording_source == RecordingSource::None {

--- a/src-tauri/src/shortcuts/shortcuts.rs
+++ b/src-tauri/src/shortcuts/shortcuts.rs
@@ -160,27 +160,21 @@ fn pushtotalk_recording_action<F>(
 {
     let mut recording_source = recording_state().source.lock();
 
+    // Push-to-talk mirrors the physical key state 1:1: start on press, stop on
+    // release. X11 auto-repeat (synthetic Release+Press bursts) is already
+    // filtered upstream in platform_linux, and Windows/macOS poll the real key
+    // state, so a Release here is always a genuine physical release. A cooldown
+    // would swallow legitimate quick taps and make push-to-talk behave like
+    // toggle, so none is applied (unlike ToggleToTalk).
     match event_type {
         KeyEventType::Pressed => {
             if *recording_source == RecordingSource::None {
-                if within_cooldown(&recording_state().last_toggle_stop) {
-                    info!("PushToTalk press ignored (cooldown after stop)");
-                    return;
-                }
                 start_recording(app, &mut recording_source, target, start_fn);
             }
         }
         KeyEventType::Released => {
             if *recording_source == target {
-                // Symmetric with ToggleToTalk: drop Release events within the
-                // start cooldown so synthetic Release+Press pairs (X11 auto-repeat)
-                // cannot stop recording mid-utterance.
-                if within_cooldown(&recording_state().last_toggle_start) {
-                    info!("PushToTalk release ignored (cooldown after start)");
-                    return;
-                }
                 pre_stop(app, &mut recording_source);
-                *recording_state().last_toggle_stop.lock() = Instant::now();
                 drop(recording_source);
                 finish_stop(app);
             }


### PR DESCRIPTION
## Description

Since 1.9.0, push-to-talk does not stop reliably on key release: there is a perceived delay, and a quick tap leaves recording running so push-to-talk behaves like toggle. This restores immediate stop-on-release.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other:

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [ ] I checked for SonarQube issues on the draft PR

## Details

Root cause: `5a2819e` added a 250 ms "cooldown after start" to the push-to-talk **release** path. Any release within 250 ms of the start was ignored, so quick taps (< 250 ms hold) never stopped recording.

The same PR also added the proper auto-repeat protection at the right layer — the `pending_release` / 25 ms window in `platform_linux/mod.rs` swallows X11 auto-repeat (synthetic Release+Press bursts) before they reach the recording logic. Windows and macOS poll the physical key state, so they never emit synthetic releases either. The Wayland portal bursts the cooldown also guarded against no longer exist since the portal was removed in `4ac0562` (Wayland is CLI-only now).

This PR removes both push-to-talk cooldowns so recording mirrors the physical key state 1:1 (start on press, stop on release). `ToggleToTalk` keeps its own cooldown, which it still needs and where it does not harm UX.
