### PR TITLE
feat: replace linear resampling with anti-aliased sinc (rubato)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,21 +117,22 @@ See [CHANGELOG.md](./CHANGELOG.md).
 ## 🗺️ Roadmap
 
 ### Backlog
-
+- [ ] (1.10.0) feat(audio): Replace linear resampling with anti-aliased sinc resampling (rubato) to improve transcription accuracy on low-end microphones
+- [ ] (1.10.0) feat(dictionary): Improve dictionary accuracy via Parakeet phrase boosting https://github.com/Kieirra/murmure/issues/338
+- [ ] (1.10.0) feat(audio) Optimizing parakeet onnx to better result
+- [ ] (1.10.0) feat(audio): Lower output volume while recording https://github.com/Kieirra/murmure/issues/364
 - [ ] (1.10.0) feat(shortcuts): Delete key removes the selected shortcut
 - [ ] (1.10.0) fix(shortcuts): Prevent adding a duplicate shortcut
-- [ ] (1.10.0) feat(dictionary): Virtualize the list to handle large dictionaries
-- [ ] (1.10.0) feat(dictionary): Improve dictionary accuracy via Parakeet phrase boosting https://github.com/Kieirra/murmure/issues/338
 - [ ] (1.10.0) feat(overlay): Close button to cancel an ongoing transcription https://github.com/Kieirra/murmure/discussions/305#discussioncomment-16928389
-- [ ] (1.10.0) feat(llm): Built-in prompt preset for input anonymisation
-- [ ] (1.10.0) fix(visualizer): Always reset the visualizer at the end of a transcription
-- [ ] (1.10.0) fix(api): Remove the experimental tag and consolidate the API
-- [ ] (1.10.0) fix(api): Implement LLM Connect service
-- [ ] (1.10.0) fix(onboarding): Improve UI onboarding non-wayland
 - [ ] (1.10.0) feat(insert): None option for Text Insert Mode to disable auto-insertion https://github.com/Kieirra/murmure/issues/349
 - [ ] (1.10.0) feat(overlay): Countdown timer shown in the last minute before the recording limit https://github.com/Kieirra/murmure/issues/359
 - [ ] (1.10.0) feat(dictation): Long dictation mode (VAD) that writes on silence to bypass the 5-minute limit https://github.com/Kieirra/murmure/issues/359
-- [ ] (1.10.0) feat(audio): Lower output volume while recording https://github.com/Kieirra/murmure/issues/364
+- [ ] (1.10.0) fix(api): Remove the experimental tag and consolidate the API
+- [ ] (1.10.0) fix(api): Implement LLM Connect service
+- [ ] (1.10.0) fix(visualizer): Always reset the visualizer at the end of a transcription
+- [ ] (1.10.0) feat(llm): Built-in prompt preset for input anonymisation
+- [ ] (1.10.0) fix(onboarding): Improve UI onboarding non-wayland
+- [ ] (1.10.0) feat(dictionary): Virtualize the list to handle large dictionaries
 - [ ] (1.10.0) (under consideration) fix(audio): Band-limited resampling with anti-aliasing low-pass filter to improve transcription quality on non-16kHz mics
 - [ ] (under consideration) (1.10.0) fix(api): Auto-split long audio for LLM transcription
 - [ ] (under consideration) (1.10.0) feat(draft): Draft Mode to review and edit a transcription before writing (medical use case)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ See [CHANGELOG.md](./CHANGELOG.md).
 ## 🗺️ Roadmap
 
 ### Backlog
-- [ ] (1.10.0) feat(audio): Replace linear resampling with anti-aliased sinc resampling (rubato) to improve transcription accuracy on low-end microphones
+- [ ] (1.10.0) feat(audio): Improve transcription accuracy with higher quality audio resampling, especially on low-end microphones
 - [ ] (1.10.0) feat(dictionary): Improve dictionary accuracy via Parakeet phrase boosting https://github.com/Kieirra/murmure/issues/338
 - [ ] (1.10.0) feat(audio) Optimizing parakeet onnx to better result
 - [ ] (1.10.0) feat(audio): Lower output volume while recording https://github.com/Kieirra/murmure/issues/364

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ See [CHANGELOG.md](./CHANGELOG.md).
 ## 🗺️ Roadmap
 
 ### Backlog
-- [ ] (1.10.0) feat(audio): Improve transcription accuracy with higher quality audio resampling, especially on low-end microphones
+- [x] (1.10.0) feat(audio): Improve transcription accuracy with higher quality audio resampling, especially on low-end microphones
 - [ ] (1.10.0) feat(dictionary): Improve dictionary accuracy via Parakeet phrase boosting https://github.com/Kieirra/murmure/issues/338
 - [ ] (1.10.0) feat(audio) Optimizing parakeet onnx to better result
 - [ ] (1.10.0) feat(audio): Lower output volume while recording https://github.com/Kieirra/murmure/issues/364

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -303,6 +303,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audio-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audioadapter"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+dependencies = [
+ "audio-core",
+ "num-traits",
+]
+
+[[package]]
 name = "auto-launch"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,6 +3359,7 @@ dependencies = [
  "reqwest",
  "rodio",
  "rphonetic",
+ "rubato",
  "rustls",
  "serde",
  "serde_json",
@@ -4447,6 +4485,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4868,6 +4915,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5104,6 +5160,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7204ed6420f698836b76d4d5c2ec5dec7585fd5c3a788fd1cde855d1de598239"
 
 [[package]]
+name = "rubato"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4be9c88e3d722d3d36939e41941f6b6f52810c1235bf19998a7d4535b402892"
+dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+ "visibility",
+ "windowfunctions",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5132,6 +5204,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -5772,6 +5858,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -6998,6 +7090,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "tray-icon"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7258,6 +7360,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "vswhom"
@@ -7680,6 +7793,15 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,6 +63,7 @@ socket2 = "0.6"
 local-ip-address = "0.6"
 base64 = "0.22"
 hostname = "0.4"
+rubato = "3.0.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-autostart = "2"

--- a/src-tauri/src/audio/helpers.rs
+++ b/src-tauri/src/audio/helpers.rs
@@ -2,6 +2,11 @@ use anyhow::{Context, Result};
 
 use hound::{WavSpec, WavWriter};
 use log::warn;
+use rubato::audioadapter_buffers::direct::InterleavedSlice;
+use rubato::{
+    calculate_cutoff, Async, FixedAsync, Resampler, SincInterpolationParameters,
+    SincInterpolationType, WindowFunction,
+};
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
@@ -88,7 +93,7 @@ pub fn read_wav_samples(wav_path: &Path) -> Result<Vec<f32>> {
         .collect();
 
     let out = if spec.sample_rate != 16000 {
-        resample_linear(&samples_f32, spec.sample_rate as usize, 16000)
+        resample(&samples_f32, spec.sample_rate as usize, 16000)
     } else {
         samples_f32
     };
@@ -96,29 +101,43 @@ pub fn read_wav_samples(wav_path: &Path) -> Result<Vec<f32>> {
     Ok(out)
 }
 
-pub fn resample_linear(input: &[f32], src_hz: usize, dst_hz: usize) -> Vec<f32> {
+pub fn resample(input: &[f32], src_hz: usize, dst_hz: usize) -> Vec<f32> {
     if input.is_empty() || src_hz == 0 || dst_hz == 0 {
         return Vec::new();
     }
     if src_hz == dst_hz {
         return input.to_vec();
     }
+
+    resample_inner(input, src_hz, dst_hz).unwrap_or_else(|e| {
+        warn!("Resampling failed ({src_hz}->{dst_hz}): {e}");
+        Vec::new()
+    })
+}
+
+fn resample_inner(input: &[f32], src_hz: usize, dst_hz: usize) -> Result<Vec<f32>> {
     let ratio = dst_hz as f64 / src_hz as f64;
-    let out_len = ((input.len() as f64) * ratio).ceil() as usize;
-    if out_len == 0 {
-        return Vec::new();
-    }
-    let mut out = Vec::with_capacity(out_len);
-    let last_idx = input.len().saturating_sub(1);
-    for i in 0..out_len {
-        let t = (i as f64) / ratio;
-        let idx = t.floor() as usize;
-        let frac = (t - idx as f64) as f32;
-        let a = input[idx];
-        let b = input[std::cmp::min(idx + 1, last_idx)];
-        out.push(a + (b - a) * frac);
-    }
-    out
+    let sinc_len = 128;
+    let window = WindowFunction::BlackmanHarris2;
+    let params = SincInterpolationParameters {
+        sinc_len,
+        f_cutoff: calculate_cutoff(sinc_len, window),
+        oversampling_factor: 256,
+        interpolation: SincInterpolationType::Linear,
+        window,
+    };
+
+    let mut resampler = Async::<f32>::new_sinc(ratio, 1.0, &params, 1024, 1, FixedAsync::Input)?;
+
+    let mut output = vec![0.0f32; resampler.process_all_needed_output_len(input.len())];
+    let in_adapter = InterleavedSlice::new(input, 1, input.len())?;
+    let out_capacity = output.len();
+    let mut out_adapter = InterleavedSlice::new_mut(&mut output, 1, out_capacity)?;
+
+    let (_, nbr_out) =
+        resampler.process_all_into_buffer(&in_adapter, &mut out_adapter, input.len(), None)?;
+    output.truncate(nbr_out);
+    Ok(output)
 }
 
 pub fn create_wav_writer(
@@ -134,4 +153,105 @@ pub fn create_wav_writer(
         sample_format: hound::SampleFormat::Int,
     };
     WavWriter::new(writer, spec).context("Failed to create WAV writer")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f32::consts::PI;
+
+    fn sine(freq_hz: f32, sample_rate: usize, duration_s: f32) -> Vec<f32> {
+        let n = (sample_rate as f32 * duration_s) as usize;
+        (0..n)
+            .map(|i| (2.0 * PI * freq_hz * i as f32 / sample_rate as f32).sin())
+            .collect()
+    }
+
+    fn rms(samples: &[f32]) -> f32 {
+        if samples.is_empty() {
+            return 0.0;
+        }
+        let sum_sq: f32 = samples.iter().map(|s| s * s).sum();
+        (sum_sq / samples.len() as f32).sqrt()
+    }
+
+    fn linear_reference(input: &[f32], src_hz: usize, dst_hz: usize) -> Vec<f32> {
+        let ratio = dst_hz as f64 / src_hz as f64;
+        let out_len = ((input.len() as f64) * ratio).ceil() as usize;
+        let last_idx = input.len().saturating_sub(1);
+        (0..out_len)
+            .map(|i| {
+                let t = i as f64 / ratio;
+                let idx = t.floor() as usize;
+                let frac = (t - idx as f64) as f32;
+                let a = input[idx.min(last_idx)];
+                let b = input[(idx + 1).min(last_idx)];
+                a + (b - a) * frac
+            })
+            .collect()
+    }
+
+    #[test]
+    fn should_return_empty_vec_when_input_is_empty() {
+        assert_eq!(resample(&[], 48000, 16000), Vec::<f32>::new());
+    }
+
+    #[test]
+    fn should_return_empty_vec_when_a_sample_rate_is_zero() {
+        let signal = sine(1000.0, 48000, 0.1);
+        assert_eq!(resample(&signal, 0, 16000), Vec::<f32>::new());
+        assert_eq!(resample(&signal, 48000, 0), Vec::<f32>::new());
+    }
+
+    #[test]
+    fn should_return_input_unchanged_when_src_equals_dst() {
+        let signal = sine(1000.0, 16000, 0.1);
+        assert_eq!(resample(&signal, 16000, 16000), signal);
+    }
+
+    #[test]
+    fn should_produce_expected_length_without_nan_when_downsampling_48k_to_16k() {
+        let signal = sine(1000.0, 48000, 1.0);
+        let out = resample(&signal, 48000, 16000);
+
+        let expected = signal.len() * 16000 / 48000;
+        let block = 1024;
+        assert!((out.len() as i64 - expected as i64).unsigned_abs() as usize <= block);
+        assert!(out.iter().all(|s| s.is_finite()));
+    }
+
+    #[test]
+    fn should_attenuate_above_nyquist_component_when_downsampling() {
+        // 12 kHz at 48 kHz is above the 16 kHz Nyquist (8 kHz). Linear interpolation
+        // folds it back into the audible band; rubato's sinc filter removes it.
+        let signal = sine(12000.0, 48000, 1.0);
+
+        let rubato_out = resample(&signal, 48000, 16000);
+        let linear_out = linear_reference(&signal, 48000, 16000);
+
+        assert!(rubato_out.iter().all(|s| s.is_finite()));
+        assert!(rms(&rubato_out) < rms(&linear_out) * 0.2);
+    }
+
+    #[test]
+    fn should_not_panic_and_double_length_when_upsampling_8k_to_16k() {
+        let signal = sine(1000.0, 8000, 0.5);
+        let out = resample(&signal, 8000, 16000);
+
+        let expected = signal.len() * 2;
+        let block = 2048;
+        assert!((out.len() as i64 - expected as i64).unsigned_abs() as usize <= block);
+        assert!(out.iter().all(|s| s.is_finite()));
+    }
+
+    #[test]
+    fn should_produce_coherent_length_when_ratio_is_fractional_44100_to_16000() {
+        let signal = sine(1000.0, 44100, 1.0);
+        let out = resample(&signal, 44100, 16000);
+
+        let expected = (signal.len() as f64 * 16000.0 / 44100.0) as usize;
+        let block = 2048;
+        assert!((out.len() as i64 - expected as i64).unsigned_abs() as usize <= block);
+        assert!(out.iter().all(|s| s.is_finite()));
+    }
 }

--- a/src-tauri/src/audio/streaming.rs
+++ b/src-tauri/src/audio/streaming.rs
@@ -1,4 +1,4 @@
-use crate::audio::helpers::resample_linear;
+use crate::audio::helpers::resample;
 use crate::audio::types::AudioState;
 use crate::dictionary::{fix_transcription_with_dictionary, get_cc_rules_path, Dictionary};
 use crate::engine::transcription_engine::TranscriptionEngine;
@@ -352,7 +352,7 @@ fn drain_shared_buffer(buffer: &Arc<Mutex<Vec<f32>>>) -> Vec<f32> {
 
 fn transcribe_samples(app: &AppHandle, samples: &[f32], sample_rate: u32) -> Option<String> {
     let resampled = if sample_rate != 16000 {
-        resample_linear(samples, sample_rate as usize, 16000)
+        resample(samples, sample_rate as usize, 16000)
     } else {
         samples.to_vec()
     };

--- a/src-tauri/src/smartmic/audio_bridge.rs
+++ b/src-tauri/src/smartmic/audio_bridge.rs
@@ -1,4 +1,4 @@
-use crate::audio::helpers::resample_linear;
+use crate::audio::helpers::resample;
 
 /// Maximum recording samples: 5 minutes at 16 kHz
 const MAX_RECORDING_SAMPLES: usize = 4_800_000;
@@ -33,7 +33,7 @@ pub fn finalize_buffer(buffer: Vec<i16>, source_sample_rate: u32) -> Vec<f32> {
 
     // Resample to 16kHz if needed
     if source_sample_rate != 16000 {
-        resample_linear(&samples_f32, source_sample_rate as usize, 16000)
+        resample(&samples_f32, source_sample_rate as usize, 16000)
     } else {
         samples_f32
     }

--- a/src-tauri/src/wake_word/wake_word.rs
+++ b/src-tauri/src/wake_word/wake_word.rs
@@ -1,4 +1,4 @@
-use crate::audio::helpers::resample_linear;
+use crate::audio::helpers::resample;
 use crate::audio::types::{AudioState, RecordingMode, RecordingTrigger};
 use crate::engine::transcription_engine::TranscriptionEngine;
 use crate::engine::ParakeetModelParams;
@@ -660,7 +660,7 @@ fn resample_and_transcribe(
     sample_rate: usize,
 ) -> Option<(String, String)> {
     let samples_16k = if sample_rate != 16000 {
-        resample_linear(samples, sample_rate, 16000)
+        resample(samples, sample_rate, 16000)
     } else {
         samples.to_vec()
     };


### PR DESCRIPTION
## Description

Replace the homemade linear interpolation resampler with rubato (sinc interpolation with anti-aliasing). Removes spectral aliasing when downsampling 44.1/48 kHz mics to 16 kHz, which polluted the signal sent to the Parakeet ASR model, especially on low-end microphones.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [x] I checked for SonarQube issues on the draft PR

## Related issues

Language switching / French-English mixing reports: #361 #365 #366 (open) — #70 #209 #238 #248 #254 #268 #276 #291 #295 #299 #309 #330 (closed)
