### PR TITLE
feat: CLI transcription of audio files

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ See [CHANGELOG.md](./CHANGELOG.md).
 - [x] feat(overlay): Close button to cancel an ongoing transcription https://github.com/Kieirra/murmure/discussions/305#discussioncomment-16928389
 - [x] feat(insert): None option for Text Insert Mode to disable auto-insertion https://github.com/Kieirra/murmure/issues/349
 - [x] chore(deps): Fix security vulnerabilities flagged by Dependabot and dependency audits
-- [ ] feat(cli): Murmure command to easily transcribe audio from the terminal 
+- [x] feat(cli): Murmure command to easily transcribe audio from the terminal 
 - [ ] fix(shortcuts): Fix push-to-talk recording toggling on/off on X11 caused by key auto-repeat https://github.com/Kieirra/murmure/issues/377
 
 ### Backlog

--- a/src-tauri/src/audio/chunking.rs
+++ b/src-tauri/src/audio/chunking.rs
@@ -178,12 +178,13 @@ pub(super) struct Chunker {
     arm_samples: usize,
     force_samples: usize,
     overlap_samples: usize,
-    silence_ms: u64,
+    silence_cut_samples: usize,
+    silence_run: usize,
+    last_tick_len: usize,
     seq: u64,
     samples: Vec<f32>,
     overlap_prefix: usize,
     vad: LiveTextVad,
-    silence_start: Option<std::time::Instant>,
 }
 
 impl Chunker {
@@ -195,12 +196,13 @@ impl Chunker {
             arm_samples: CHUNK_SILENCE_ARM_SECS as usize * sr,
             force_samples: CHUNK_FORCE_CUT_SECS as usize * sr,
             overlap_samples: (CHUNK_FORCED_OVERLAP_SECS * sample_rate as f32) as usize,
-            silence_ms,
+            silence_cut_samples: (silence_ms as usize * sr / 1000).max(1),
+            silence_run: 0,
+            last_tick_len: 0,
             seq: 0,
             samples: Vec::new(),
             overlap_prefix: 0,
             vad: LiveTextVad::new(),
-            silence_start: None,
         }
     }
 
@@ -215,19 +217,21 @@ impl Chunker {
         }
 
         if self.samples.len() < self.arm_samples {
+            self.last_tick_len = self.samples.len();
             return;
         }
 
+        let delta = self.samples.len().saturating_sub(self.last_tick_len);
+        self.last_tick_len = self.samples.len();
+
         match self.vad.update(rms) {
             LiveTextSilence::Silent => {
-                let start = self
-                    .silence_start
-                    .get_or_insert_with(std::time::Instant::now);
-                if start.elapsed() >= std::time::Duration::from_millis(self.silence_ms) {
+                self.silence_run += delta;
+                if self.silence_run >= self.silence_cut_samples {
                     self.cut_on_silence();
                 }
             }
-            LiveTextSilence::Active => self.silence_start = None,
+            LiveTextSilence::Active => self.silence_run = 0,
             LiveTextSilence::NotStarted => {}
         }
     }
@@ -286,16 +290,57 @@ impl Chunker {
 
     fn reset_silence_state(&mut self) {
         self.vad = LiveTextVad::new();
-        self.silence_start = None;
+        self.silence_run = 0;
+        self.last_tick_len = self.samples.len();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::audio::helpers::rms;
+
+    const SR: u32 = 16000;
 
     fn dedup(acc: &str, chunk: &str) -> String {
         remove_overlap_duplication(acc, chunk)
+    }
+
+    fn drive_chunker(samples: &[f32], silence_ms: u64) -> usize {
+        let (tx, rx) = mpsc::channel::<ChunkJob>();
+        let mut chunker = Chunker::new(tx, SR, silence_ms);
+        let window = (SR as usize * 33 / 1000).max(1);
+        for win in samples.chunks(window) {
+            chunker.push_samples(win);
+            chunker.on_throttle_tick(rms(win));
+        }
+        chunker.flush_remaining();
+        rx.try_iter()
+            .filter(|job| matches!(job, ChunkJob::Audio { .. }))
+            .count()
+    }
+
+    fn speech(secs: f32) -> Vec<f32> {
+        vec![0.1; (SR as f32 * secs) as usize]
+    }
+
+    fn silence(secs: f32) -> Vec<f32> {
+        vec![0.0; (SR as f32 * secs) as usize]
+    }
+
+    #[test]
+    fn chunker_silence_cuts_once_armed() {
+        let mut samples = speech(16.0);
+        samples.extend(silence(2.0));
+        samples.extend(speech(5.0));
+        assert_eq!(drive_chunker(&samples, 500), 2);
+    }
+
+    #[test]
+    fn chunker_no_silence_cut_below_arm() {
+        let mut samples = speech(5.0);
+        samples.extend(silence(2.0));
+        assert_eq!(drive_chunker(&samples, 500), 1);
     }
 
     #[test]

--- a/src-tauri/src/audio/helpers.rs
+++ b/src-tauri/src/audio/helpers.rs
@@ -115,6 +115,18 @@ pub fn cleanup_recordings(app: &tauri::AppHandle) -> Result<()> {
 }
 
 pub fn read_wav_samples(wav_path: &Path) -> Result<Vec<f32>> {
+    let (samples_f32, sample_rate) = read_wav_mono_native(wav_path)?;
+
+    let out = if sample_rate != 16000 {
+        resample(&samples_f32, sample_rate as usize, 16000)
+    } else {
+        samples_f32
+    };
+
+    Ok(out)
+}
+
+pub fn read_wav_mono_native(wav_path: &Path) -> Result<(Vec<f32>, u32)> {
     let mut reader = hound::WavReader::open(wav_path)?;
     let spec = reader.spec();
 
@@ -151,13 +163,15 @@ pub fn read_wav_samples(wav_path: &Path) -> Result<Vec<f32>> {
         .map(|s| s as f32 / i16::MAX as f32)
         .collect();
 
-    let out = if spec.sample_rate != 16000 {
-        resample(&samples_f32, spec.sample_rate as usize, 16000)
-    } else {
-        samples_f32
-    };
+    Ok((samples_f32, spec.sample_rate))
+}
 
-    Ok(out)
+pub fn rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f32 = samples.iter().map(|s| s * s).sum();
+    (sum_sq / samples.len() as f32).sqrt()
 }
 
 pub fn resample(input: &[f32], src_hz: usize, dst_hz: usize) -> Vec<f32> {
@@ -224,14 +238,6 @@ mod tests {
         (0..n)
             .map(|i| (2.0 * PI * freq_hz * i as f32 / sample_rate as f32).sin())
             .collect()
-    }
-
-    fn rms(samples: &[f32]) -> f32 {
-        if samples.is_empty() {
-            return 0.0;
-        }
-        let sum_sq: f32 = samples.iter().map(|s| s * s).sum();
-        (sum_sq / samples.len() as f32).sqrt()
     }
 
     fn linear_reference(input: &[f32], src_hz: usize, dst_hz: usize) -> Vec<f32> {

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -1,5 +1,6 @@
+use crate::audio::chunking::{ChunkPipeline, Chunker};
 use crate::audio::clean_recording::strip_fillers_and_repeats;
-use crate::audio::helpers::{read_wav_samples, resample};
+use crate::audio::helpers::{read_wav_mono_native, read_wav_samples, resample, rms};
 use crate::audio::types::{AudioState, RecordingMode};
 use crate::dictionary::{correct_transcription, sync_boost_words, Dictionary};
 use crate::engine::transcription_engine::{TranscriptionEngine, TranscriptionResult};
@@ -81,6 +82,19 @@ pub fn merge_all_chunks(
     file_path: &Path,
     mode: RecordingMode,
 ) -> Result<ProcessingResult> {
+    let result = post_process_chunks(app, accumulated, mode)?;
+    if !result.text.trim().is_empty() {
+        // 8. Save stats & history
+        save_stats_and_history(app, file_path, &result.text)?;
+    }
+    Ok(result)
+}
+
+fn post_process_chunks(
+    app: &AppHandle,
+    accumulated: String,
+    mode: RecordingMode,
+) -> Result<ProcessingResult> {
     if accumulated.trim().is_empty() {
         return Ok(ProcessingResult {
             text: accumulated,
@@ -94,13 +108,40 @@ pub fn merge_all_chunks(
     let (llm_text, llm_error) = apply_llm_processing_with_error(app, text, mode)?;
     // 7. Apply formatting rules
     let final_text = apply_formatting_rules(app, llm_text);
-    // 8. Save stats & history
-    save_stats_and_history(app, file_path, &final_text)?;
 
     Ok(ProcessingResult {
         text: final_text,
         llm_error,
     })
+}
+
+pub fn transcribe_file_chunked(app: &AppHandle, file_path: &Path) -> Result<String> {
+    let (samples, sample_rate) = read_wav_mono_native(file_path)?;
+    if samples.is_empty() {
+        return Err(anyhow::anyhow!("Audio file contains no samples"));
+    }
+
+    let silence_ms = crate::settings::load_settings(app)
+        .long_dictation_silence_ms
+        .clamp(250, 3000);
+
+    let pipeline = ChunkPipeline::start(app);
+    let mut chunker = Chunker::new(pipeline.sender(), sample_rate, silence_ms);
+    let window = (sample_rate as usize * 33 / 1000).max(1);
+    for win in samples.chunks(window) {
+        chunker.push_samples(win);
+        chunker.on_throttle_tick(rms(win));
+    }
+    chunker.flush_remaining();
+    let accumulated = pipeline.finalize();
+
+    let result = post_process_chunks(app, accumulated, RecordingMode::Standard)?;
+    let text = result.text.trim().to_string();
+    if text.is_empty() {
+        return Err(anyhow::anyhow!("Transcription produced no text"));
+    }
+
+    Ok(text)
 }
 
 pub fn process_whole_recording(app: &AppHandle, file_path: &Path) -> Result<ProcessingResult> {

--- a/src-tauri/src/cli/cli.rs
+++ b/src-tauri/src/cli/cli.rs
@@ -1,4 +1,4 @@
-use super::helpers::{parse_llm_mode, parse_strategy};
+use super::helpers::{parse_file_arg, parse_llm_mode, parse_strategy};
 use super::types::{CliCommand, ImportStrategy};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -42,6 +42,7 @@ Murmure - Privacy-first speech-to-text
 USAGE:
     murmure [OPTIONS]
     murmure import <FILE> [IMPORT_OPTIONS]
+    murmure transcribe <FILE>
 
 OPTIONS:
     --transcription              Toggle standard transcription on/off
@@ -65,13 +66,27 @@ IMPORT:
     IMPORT_OPTIONS:
         -s, --strategy <STRATEGY>    Import strategy: replace (default) or merge
 
+TRANSCRIBE:
+    Transcribe an audio file and print the text to stdout, then exit.
+
+    USAGE:
+        murmure transcribe <FILE> [TRANSCRIBE_OPTIONS]
+
+    ARGS:
+        <FILE>    Path to the WAV file to transcribe
+
+    TRANSCRIBE_OPTIONS:
+        -v, --verbose    Print full logs to stderr (errors only by default)
+
 EXAMPLES:
     murmure --transcription
     murmure --paste-last
     murmure --llm-mode 2
     murmure import config.murmure
     murmure import config.murmure --strategy merge
-    murmure import config.murmure -s replace",
+    murmure import config.murmure -s replace
+    murmure transcribe recording.wav
+    murmure transcribe recording.wav -v",
         VERSION
     );
 }
@@ -83,15 +98,21 @@ EXAMPLES:
 /// - `Err(msg)`: a recognised command with invalid arguments. Cold path callers
 ///   should surface `msg` and exit; hot path callers should log and stay alive.
 pub fn parse_raw_args(args: &[String]) -> Result<Option<CliCommand>, String> {
+    if let Some(index) = args.iter().position(|a| a == "transcribe") {
+        let file_path = args[index + 1..].iter().find(|a| !a.starts_with('-'));
+        return match file_path {
+            Some(path) => Ok(Some(CliCommand::Transcribe {
+                file_path: path.clone(),
+            })),
+            None => Ok(None),
+        };
+    }
+
     if let Some(import_index) = args.iter().position(|a| a == "import") {
-        let file_path = match args.get(import_index + 1) {
-            Some(p) => p.clone(),
+        let file_path = match parse_file_arg(args, "import") {
+            Some(p) => p,
             None => return Ok(None),
         };
-
-        if file_path.starts_with('-') {
-            return Ok(None);
-        }
 
         let mut strategy = ImportStrategy::Replace;
 
@@ -268,6 +289,68 @@ mod tests {
         let args = vec![
             "murmure".to_string(),
             "import".to_string(),
+            "--something".to_string(),
+        ];
+        let result = parse_raw_args(&args).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_raw_args_basic_transcribe() {
+        let args = vec![
+            "murmure".to_string(),
+            "transcribe".to_string(),
+            "/tmp/recording.wav".to_string(),
+        ];
+        let result = parse_raw_args(&args).unwrap();
+        match result {
+            Some(CliCommand::Transcribe { file_path }) => {
+                assert_eq!(file_path, "/tmp/recording.wav");
+            }
+            other => panic!("expected Transcribe, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_raw_args_transcribe_without_file() {
+        let args = vec!["murmure".to_string(), "transcribe".to_string()];
+        let result = parse_raw_args(&args).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_raw_args_transcribe_verbose_before_file() {
+        let args = vec![
+            "murmure".to_string(),
+            "transcribe".to_string(),
+            "-v".to_string(),
+            "1.wav".to_string(),
+        ];
+        match parse_raw_args(&args).unwrap() {
+            Some(CliCommand::Transcribe { file_path }) => assert_eq!(file_path, "1.wav"),
+            other => panic!("expected Transcribe, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_raw_args_transcribe_verbose_after_file() {
+        let args = vec![
+            "murmure".to_string(),
+            "transcribe".to_string(),
+            "1.wav".to_string(),
+            "-v".to_string(),
+        ];
+        match parse_raw_args(&args).unwrap() {
+            Some(CliCommand::Transcribe { file_path }) => assert_eq!(file_path, "1.wav"),
+            other => panic!("expected Transcribe, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_raw_args_transcribe_file_starts_with_dash() {
+        let args = vec![
+            "murmure".to_string(),
+            "transcribe".to_string(),
             "--something".to_string(),
         ];
         let result = parse_raw_args(&args).unwrap();

--- a/src-tauri/src/cli/helpers.rs
+++ b/src-tauri/src/cli/helpers.rs
@@ -11,6 +11,15 @@ pub(super) fn parse_strategy(value: &str) -> Result<ImportStrategy, String> {
     }
 }
 
+pub(super) fn parse_file_arg(args: &[String], keyword: &str) -> Option<String> {
+    let index = args.iter().position(|a| a == keyword)?;
+    let file_path = args.get(index + 1)?;
+    if file_path.starts_with('-') {
+        return None;
+    }
+    Some(file_path.clone())
+}
+
 pub(super) fn parse_llm_mode(value: &str) -> Result<u8, String> {
     match value.parse::<u8>() {
         Ok(n) if (1..=4).contains(&n) => Ok(n),

--- a/src-tauri/src/cli/types.rs
+++ b/src-tauri/src/cli/types.rs
@@ -12,6 +12,9 @@ pub enum CliCommand {
         file_path: String,
         strategy: ImportStrategy,
     },
+    Transcribe {
+        file_path: String,
+    },
     Transcription,
     TranscriptionCommand,
     PasteLast,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,14 +70,26 @@ pub fn run() {
         log::warn!("Rustls crypto provider was already installed");
     }
 
-    tauri::Builder::default()
+    let is_transcribe = matches!(
+        cli::parse_raw_args(&std::env::args().collect::<Vec<_>>()),
+        Ok(Some(cli::CliCommand::Transcribe { .. }))
+    );
+
+    // transcribe keeps stdout for the transcription only; logs go to stderr.
+    let log_targets = if is_transcribe {
+        vec![Target::new(TargetKind::Stderr)]
+    } else {
+        vec![
+            Target::new(TargetKind::Stdout),
+            Target::new(TargetKind::Webview),
+            Target::new(TargetKind::LogDir { file_name: None }),
+        ]
+    };
+
+    let mut builder = tauri::Builder::default()
         .plugin(
             tauri_plugin_log::Builder::new()
-                .targets([
-                    Target::new(TargetKind::Stdout),
-                    Target::new(TargetKind::Webview),
-                    Target::new(TargetKind::LogDir { file_name: None }),
-                ])
+                .targets(log_targets)
                 .timezone_strategy(TimezoneStrategy::UseLocal)
                 .max_file_size(1024 * 1024) // 1 MB, rotation
                 .level(log::LevelFilter::Trace)
@@ -96,8 +108,10 @@ pub fn run() {
         )
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
+        .plugin(tauri_plugin_updater::Builder::new().build());
+
+    if !is_transcribe {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
             match cli::parse_raw_args(&args) {
                 Ok(Some(cli::CliCommand::Import {
                     file_path,
@@ -126,7 +140,10 @@ pub fn run() {
                     show_main_window(app);
                 }
             }
-        }))
+        }));
+    }
+
+    builder
         .plugin(
             tauri_plugin_autostart::Builder::new()
                 .arg("--autostart")
@@ -203,7 +220,14 @@ pub fn run() {
                 app.set_activation_policy(policy);
             }
 
-            if let Ok(level) = log::LevelFilter::from_str(&s.log_level) {
+            if matches!(pending_cli_action, Some(cli::CliCommand::Transcribe { .. })) {
+                let verbose = std::env::args().any(|a| a == "-v" || a == "--verbose");
+                log::set_max_level(if verbose {
+                    log::LevelFilter::Debug
+                } else {
+                    log::LevelFilter::Error
+                });
+            } else if let Ok(level) = log::LevelFilter::from_str(&s.log_level) {
                 log::set_max_level(level);
             }
 
@@ -215,6 +239,27 @@ pub fn run() {
                 dictionary::load(app.handle())?
             };
             app.manage(Dictionary::new(dictionary.clone()));
+
+            if let Some(cli::CliCommand::Transcribe { file_path }) = &pending_cli_action {
+                if let Some(main_window) = app.get_webview_window("main") {
+                    let _ = main_window.hide();
+                }
+                match audio::pipeline::transcribe_file_chunked(
+                    app.handle(),
+                    std::path::Path::new(file_path),
+                ) {
+                    Ok(text) => {
+                        println!("{}", text);
+                        app.handle().exit(0);
+                    }
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        app.handle().exit(1);
+                    }
+                }
+                return Ok(());
+            }
+
             app.manage(HttpApiState::new());
             app.manage(SmartMicState::new());
             app.manage(utils::enigo_session::EnigoState::default());

--- a/src-tauri/src/shortcuts/cli_dispatch.rs
+++ b/src-tauri/src/shortcuts/cli_dispatch.rs
@@ -34,6 +34,9 @@ pub fn dispatch(app: &AppHandle, cmd: &CliCommand) {
         CliCommand::Import { .. } => {
             warn!("cli_dispatch::dispatch called with Import; handled separately");
         }
+        CliCommand::Transcribe { .. } => {
+            warn!("cli_dispatch::dispatch called with Transcribe; handled separately");
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Adds a `murmure transcribe <file>` CLI command that decodes and transcribes an audio file using the local ASR engine, printing the result to stdout. The Tauri window does not start.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other: <!-- specify -->

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [ ] I checked for SonarQube issues on the draft PR

## Screenshots (if applicable)

<!-- Paste screenshots here or remove this section. -->