### PR TITLE
feat: unify transcription paths through chunked pipeline

### DIFF
--- a/src-tauri/src/audio/audio.rs
+++ b/src-tauri/src/audio/audio.rs
@@ -1,6 +1,5 @@
 use crate::audio::clean_recording::strip_and_record;
 use crate::audio::helpers::{cleanup_recordings, ensure_recordings_dir, generate_unique_wav_name};
-use crate::audio::pipeline::process_whole_recording;
 use crate::audio::recorder::AudioRecorder;
 use crate::audio::types::{AudioState, RecorderStartError, RecordingMode, RecordingTrigger};
 use crate::audio::ChunkPipeline;
@@ -10,7 +9,6 @@ use crate::model::Model;
 use crate::overlay::overlay;
 use anyhow::Result;
 use log::{debug, error, info, warn};
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -27,17 +25,25 @@ pub fn record_audio(app: &AppHandle, mode: RecordingMode) {
 
     let settings = crate::settings::load_settings(app);
     match state.get_recording_trigger() {
-        RecordingTrigger::WakeWord => {
-            state.live_text_active.store(false, Ordering::SeqCst);
-            *state.chunk_pipeline.lock() = None;
-        }
         _ if settings.long_dictation_enabled && mode == RecordingMode::Standard => {
-            state.live_text_active.store(true, Ordering::SeqCst);
-            *state.chunk_pipeline.lock() = None;
+            let app_cb = app.clone();
+            let on_chunk: Arc<dyn Fn(String) + Send + Sync> = Arc::new(move |text: String| {
+                if let Err(e) = crate::clipboard::paste(&text, &app_cb) {
+                    error!("Long dictation: failed to paste chunk: {}", e);
+                }
+            });
+            *state.chunk_pipeline.lock() = Some(ChunkPipeline::start(
+                app,
+                Some(on_chunk),
+                crate::audio::chunking::LONG_DICTATION_SILENCE_ARM_SECS,
+            ));
         }
         _ => {
-            state.live_text_active.store(false, Ordering::SeqCst);
-            *state.chunk_pipeline.lock() = Some(ChunkPipeline::start(app));
+            *state.chunk_pipeline.lock() = Some(ChunkPipeline::start(
+                app,
+                None,
+                crate::audio::chunking::CHUNK_SILENCE_ARM_SECS,
+            ));
         }
     }
 
@@ -109,18 +115,26 @@ fn start_new_recorder(app: &AppHandle, play_sound: bool) -> Result<u32, Recorder
     Ok(sample_rate)
 }
 
-fn notify_recording_error(app: &AppHandle) {
-    let s = crate::settings::load_settings(app);
-    let mic_name = s.mic_label.or(s.mic_id).unwrap_or_default();
+fn show_recording_notification(app: &AppHandle, event: &'static str, payload: String) {
     overlay::clear_pending_flash(app);
     overlay::show_recording_overlay(app);
     let app_clone = app.clone();
     std::thread::spawn(move || {
         std::thread::sleep(std::time::Duration::from_millis(500));
-        let _ = app_clone.emit("recording-error", mic_name);
+        let _ = app_clone.emit(event, payload);
         std::thread::sleep(std::time::Duration::from_millis(1500));
         overlay::hide_recording_overlay(&app_clone);
     });
+}
+
+fn notify_recording_error(app: &AppHandle) {
+    let s = crate::settings::load_settings(app);
+    let mic_name = s.mic_label.or(s.mic_id).unwrap_or_default();
+    show_recording_notification(app, "recording-error", mic_name);
+}
+
+pub fn notify_recording_limit(app: &AppHandle) {
+    show_recording_notification(app, "recording-limit-reached", String::new());
 }
 
 pub fn stop_recording(app: &AppHandle) -> Option<std::path::PathBuf> {
@@ -152,23 +166,19 @@ pub fn stop_recording(app: &AppHandle) -> Option<std::path::PathBuf> {
         .zip(file_name_opt)
         .map(|(dir, name)| dir.join(name));
 
-    match path.as_ref() {
-        Some(p) => {
+    match (path.as_ref(), pipeline) {
+        (Some(p), Some(pipeline)) => {
             info!(
                 "Audio recording stopped; file written to temporary path: {}",
                 p.display()
             );
-            match pipeline {
-                Some(pipeline) => finalize_chunked_session(app, &state, pipeline, p),
-                None => finalize_single_recording(app, &state, p),
-            }
+            finalize_chunked_session(app, &state, pipeline, p);
         }
-        None => {
-            debug!("Recording stopped (no active file)");
+        _ => {
+            debug!("Recording stopped (no active file or pipeline)");
             reset_recording_ui(app);
         }
     }
-    state.live_text_active.store(false, Ordering::SeqCst);
 
     path
 }
@@ -194,23 +204,6 @@ fn finalize_chunked_session(
         }
         Err(e) => {
             error!("Finalize failed: {}", e);
-            reset_recording_ui(app);
-        }
-    }
-}
-
-/// Non-chunking session (wake word): single-shot transcription of the full WAV.
-fn finalize_single_recording(app: &AppHandle, state: &AudioState, path: &std::path::Path) {
-    match process_whole_recording(app, path) {
-        Ok(result) => {
-            let text = strip_and_record(app, state, result.text);
-            if let Err(e) = write_transcription(app, &text) {
-                error!("Failed to use clipboard: {}", e);
-            }
-            finish_recording_ui(app, result.llm_error);
-        }
-        Err(e) => {
-            error!("Processing failed: {}", e);
             reset_recording_ui(app);
         }
     }
@@ -247,7 +240,6 @@ pub fn cancel_recording(app: &AppHandle) {
     // Drop the pipeline without finalizing: the writer thread already exited, so
     // its sender is gone, and the worker drains its queue and stops.
     let _ = state.chunk_pipeline.lock().take();
-    state.live_text_active.store(false, Ordering::SeqCst);
 
     // Remove temporary WAV file
     let file_name_opt = state.current_file_name.lock().take();
@@ -262,87 +254,6 @@ pub fn cancel_recording(app: &AppHandle) {
 
     reset_recording_ui(app);
     info!("Recording cancelled by user");
-}
-
-pub(super) fn flush_and_continue_live_text(app: &AppHandle) {
-    let state = app.state::<AudioState>();
-    if !state.live_text_active.load(Ordering::SeqCst) {
-        return;
-    }
-
-    let old_path = {
-        let mut recorder_guard = state.recorder.lock();
-        let recorder = match recorder_guard.as_mut() {
-            Some(recorder) => recorder,
-            None => return,
-        };
-        if let Err(e) = recorder.stop(false) {
-            error!("Live text: failed to stop segment recorder: {}", e);
-        }
-        *recorder_guard = None;
-        state
-            .current_file_name
-            .lock()
-            .take()
-            .and_then(|name| ensure_recordings_dir(app).map(|dir| dir.join(name)).ok())
-    };
-
-    let restarted = restart_live_text_recorder(app);
-
-    match old_path {
-        Some(path) => {
-            let app = app.clone();
-            std::thread::spawn(move || {
-                // Paste directly instead of write_transcription: the latter runs a
-                // global cleanup that would delete the next segment's WAV (already
-                // being recorded). Remove only this segment's file.
-                match process_whole_recording(&app, &path) {
-                    Ok(result) => {
-                        if !result.text.trim().is_empty() {
-                            if let Err(e) = clipboard::paste(&result.text, &app) {
-                                error!("Long dictation: failed to paste segment: {}", e);
-                            }
-                        }
-                    }
-                    Err(e) => error!("Live text segment transcription failed: {}", e),
-                }
-                if let Err(e) = std::fs::remove_file(&path) {
-                    error!("Live text: failed to remove segment WAV: {}", e);
-                }
-                // Stop only after the last segment is pasted, so it is still
-                // formatted with the live-text flag active.
-                if !restarted {
-                    abort_live_text(&app);
-                }
-            });
-        }
-        None => {
-            if !restarted {
-                abort_live_text(app);
-            }
-        }
-    }
-}
-
-/// Returns false when the session can no longer record. A busy recorder is not
-/// a failure: one is already running, keep going.
-fn restart_live_text_recorder(app: &AppHandle) -> bool {
-    !matches!(
-        start_new_recorder(app, false),
-        Err(RecorderStartError::DirUnavailable
-            | RecorderStartError::InitFailed
-            | RecorderStartError::StartFailed)
-    )
-}
-
-fn abort_live_text(app: &AppHandle) {
-    error!("Live text: could not start next segment, stopping session");
-    let state = app.state::<AudioState>();
-    crate::audio::streaming::stop_streaming(app, &state);
-    state.live_text_active.store(false, Ordering::SeqCst);
-    reset_recording_state(app);
-    crate::overlay::tray::set_tray_idle(app);
-    notify_recording_error(app);
 }
 
 fn reset_recording_state(app: &AppHandle) {

--- a/src-tauri/src/audio/chunking.rs
+++ b/src-tauri/src/audio/chunking.rs
@@ -9,8 +9,10 @@ use tauri::{AppHandle, Emitter};
 
 const MERGE_WINDOW_WORDS: usize = 6;
 
-/// Once the current chunk reaches this length, a detected silence cuts it.
-const CHUNK_SILENCE_ARM_SECS: u32 = 15;
+/// Default arm length: once the current chunk reaches this, a detected silence cuts it.
+pub const CHUNK_SILENCE_ARM_SECS: u32 = 15;
+/// Arm length used for live long-dictation chunking.
+pub const LONG_DICTATION_SILENCE_ARM_SECS: u32 = 3;
 /// Hard cut applied when no silence has been detected by this length.
 const CHUNK_FORCE_CUT_SECS: u32 = 60;
 /// Tail kept as the next chunk's head so a word straddling a forced cut can be deduped.
@@ -30,22 +32,32 @@ pub struct ChunkPipeline {
     tx: Sender<ChunkJob>,
     accumulated: Arc<Mutex<String>>,
     worker: Option<JoinHandle<()>>,
+    arm_secs: u32,
 }
 
 impl ChunkPipeline {
-    pub fn start(app: &AppHandle) -> Self {
+    pub fn start(
+        app: &AppHandle,
+        on_chunk: Option<Arc<dyn Fn(String) + Send + Sync>>,
+        arm_secs: u32,
+    ) -> Self {
         let (tx, rx) = mpsc::channel::<ChunkJob>();
         let accumulated = Arc::new(Mutex::new(String::new()));
-        let worker = spawn_worker(app.clone(), rx, accumulated.clone());
+        let worker = spawn_worker(app.clone(), rx, accumulated.clone(), on_chunk);
         Self {
             tx,
             accumulated,
             worker: Some(worker),
+            arm_secs,
         }
     }
 
     pub fn sender(&self) -> Sender<ChunkJob> {
         self.tx.clone()
+    }
+
+    pub fn arm_secs(&self) -> u32 {
+        self.arm_secs
     }
 
     pub fn submit(&self, job: ChunkJob) {
@@ -72,6 +84,7 @@ fn spawn_worker(
     app: AppHandle,
     rx: Receiver<ChunkJob>,
     accumulated: Arc<Mutex<String>>,
+    on_chunk: Option<Arc<dyn Fn(String) + Send + Sync>>,
 ) -> JoinHandle<()> {
     std::thread::spawn(move || {
         let mut expected_seq: u64 = 0;
@@ -103,7 +116,12 @@ fn spawn_worker(
                         chunk_text.len()
                     );
 
-                    merge_chunk(&accumulated, &chunk_text, overlap_prefix);
+                    let delta = merge_chunk(&accumulated, &chunk_text, overlap_prefix);
+                    if !delta.trim().is_empty() {
+                        if let Some(ref cb) = on_chunk {
+                            cb(delta);
+                        }
+                    }
                 }
                 ChunkJob::Finalize => break,
             }
@@ -188,12 +206,17 @@ pub(super) struct Chunker {
 }
 
 impl Chunker {
-    pub(super) fn new(tx: Sender<ChunkJob>, sample_rate: u32, silence_ms: u64) -> Self {
+    pub(super) fn new(
+        tx: Sender<ChunkJob>,
+        sample_rate: u32,
+        silence_ms: u64,
+        arm_secs: u32,
+    ) -> Self {
         let sr = sample_rate as usize;
         Self {
             tx,
             sample_rate,
-            arm_samples: CHUNK_SILENCE_ARM_SECS as usize * sr,
+            arm_samples: arm_secs as usize * sr,
             force_samples: CHUNK_FORCE_CUT_SECS as usize * sr,
             overlap_samples: (CHUNK_FORCED_OVERLAP_SECS * sample_rate as f32) as usize,
             silence_cut_samples: (silence_ms as usize * sr / 1000).max(1),
@@ -308,7 +331,7 @@ mod tests {
 
     fn drive_chunker(samples: &[f32], silence_ms: u64) -> usize {
         let (tx, rx) = mpsc::channel::<ChunkJob>();
-        let mut chunker = Chunker::new(tx, SR, silence_ms);
+        let mut chunker = Chunker::new(tx, SR, silence_ms, CHUNK_SILENCE_ARM_SECS);
         let window = (SR as usize * 33 / 1000).max(1);
         for win in samples.chunks(window) {
             chunker.push_samples(win);

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -11,7 +11,6 @@ use crate::stats;
 use anyhow::Result;
 use log::{debug, error, info, warn};
 use std::path::Path;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -125,8 +124,13 @@ pub fn transcribe_file_chunked(app: &AppHandle, file_path: &Path) -> Result<Stri
         .long_dictation_silence_ms
         .clamp(250, 3000);
 
-    let pipeline = ChunkPipeline::start(app);
-    let mut chunker = Chunker::new(pipeline.sender(), sample_rate, silence_ms);
+    let pipeline = ChunkPipeline::start(app, None, crate::audio::chunking::CHUNK_SILENCE_ARM_SECS);
+    let mut chunker = Chunker::new(
+        pipeline.sender(),
+        sample_rate,
+        silence_ms,
+        crate::audio::chunking::CHUNK_SILENCE_ARM_SECS,
+    );
     let window = (sample_rate as usize * 33 / 1000).max(1);
     for win in samples.chunks(window) {
         chunker.push_samples(win);
@@ -142,48 +146,6 @@ pub fn transcribe_file_chunked(app: &AppHandle, file_path: &Path) -> Result<Stri
     }
 
     Ok(text)
-}
-
-pub fn process_whole_recording(app: &AppHandle, file_path: &Path) -> Result<ProcessingResult> {
-    // 1. Transcribe
-    let result = transcribe_audio(app, file_path)?;
-    let raw_text = result.text;
-    debug!("Raw transcription: {}", raw_text);
-
-    if raw_text.trim().is_empty() {
-        debug!("Transcription is empty, skipping further processing.");
-        return Ok(ProcessingResult {
-            text: raw_text,
-            llm_error: None,
-        });
-    }
-
-    // 2. Deduplicate repeated words (transcription artifact cleanup)
-    let text = strip_fillers_and_repeats(&raw_text);
-
-    // 3. Dictionary correction
-    let text = apply_dictionary_correction(app, text, &result.word_confidences)?;
-    debug!("Transcription fixed with dictionary: {}", text);
-
-    // 4. LLM Post-processing
-    let state = app.state::<AudioState>();
-    let (llm_text, llm_error) =
-        apply_llm_processing_with_error(app, text, state.get_recording_mode())?;
-
-    // 5. Apply formatting rules
-    let final_text = apply_formatting_rules(app, llm_text);
-    debug!("Transcription with formatting rules: {}", final_text);
-
-    // 6. Save Stats & History (skipped per live-text segment to avoid
-    //    flooding the 5-entry history and inflating stats).
-    if !state.live_text_active.load(Ordering::SeqCst) {
-        save_stats_and_history(app, file_path, &final_text)?;
-    }
-
-    Ok(ProcessingResult {
-        text: final_text,
-        llm_error,
-    })
 }
 
 pub fn transcribe_audio(app: &AppHandle, audio_path: &Path) -> Result<TranscriptionResult> {
@@ -299,19 +261,7 @@ fn apply_llm_processing_with_mode(
 
 fn apply_formatting_rules(app: &AppHandle, text: String) -> String {
     match formatting_rules::load(app) {
-        Ok(mut settings) => {
-            // Short-text correction strips the trailing space and lowercases each
-            // segment; in live text that would glue successive utterances
-            // together. Disable it for the session only, never persisted.
-            if app
-                .state::<AudioState>()
-                .live_text_active
-                .load(Ordering::SeqCst)
-            {
-                settings.built_in.short_text_correction = 0;
-            }
-            formatting_rules::apply_formatting(text, &settings)
-        }
+        Ok(settings) => formatting_rules::apply_formatting(text, &settings),
         Err(e) => {
             warn!("Failed to load formatting rules: {}. Skipping.", e);
             text

--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -1,6 +1,5 @@
 use crate::audio::chunking::{ChunkJob, Chunker};
 use crate::audio::helpers::create_wav_writer;
-use crate::audio::live_text::{LiveTextSilence, LiveTextVad};
 use crate::audio::sound;
 use crate::audio::types::RecordingTrigger;
 use anyhow::{Context, Error, Result};
@@ -48,12 +47,11 @@ impl AudioRecorder {
 
         let audio_state = app.state::<crate::audio::types::AudioState>();
         let recording_trigger = audio_state.get_recording_trigger();
-        let live_text_active = audio_state.live_text_active.clone();
-        let chunk_tx = audio_state
+        let chunk_cfg = audio_state
             .chunk_pipeline
             .lock()
             .as_ref()
-            .map(|pipeline| pipeline.sender());
+            .map(|pipeline| (pipeline.sender(), pipeline.arm_secs()));
 
         let (device, previous_default_source) = Self::get_device(app.clone())?;
         let config = match device
@@ -90,9 +88,8 @@ impl AudioRecorder {
             limit_reached,
             recording_trigger,
             streaming_buffer: streaming_buf,
-            chunk_tx,
+            chunk_cfg,
             sample_rate: config.sample_rate(),
-            live_text_active,
         };
 
         let (stream, writer_thread) =
@@ -194,10 +191,10 @@ struct WriterThreadCtx {
     limit_reached: Arc<AtomicBool>,
     recording_trigger: RecordingTrigger,
     streaming_buffer: Arc<Mutex<Vec<f32>>>,
-    /// Present when the session chunks its audio; the writer pushes chunks here.
-    chunk_tx: Option<Sender<ChunkJob>>,
+    /// Present when the session chunks its audio: the chunk sender and the
+    /// arm length the chunker should use.
+    chunk_cfg: Option<(Sender<ChunkJob>, u32)>,
     sample_rate: u32,
-    live_text_active: Arc<AtomicBool>,
 }
 
 fn build_stream(
@@ -275,9 +272,8 @@ fn spawn_writer_thread(
         limit_reached: limit_reached_flag,
         recording_trigger,
         streaming_buffer,
-        chunk_tx,
+        chunk_cfg,
         sample_rate,
-        live_text_active,
     } = ctx;
     std::thread::spawn(move || {
         // State for simple RMS + EMA smoothing and throttled emission
@@ -301,13 +297,8 @@ fn spawn_writer_thread(
         let mut has_speech_started = false;
 
         let chunk_silence_ms = settings.long_dictation_silence_ms.clamp(250, 3000);
-        let mut chunker = chunk_tx.map(|tx| Chunker::new(tx, sample_rate, chunk_silence_ms));
-
-        let is_live_text = live_text_active.load(Ordering::SeqCst);
-        let live_text_silence_ms = settings.long_dictation_silence_ms.clamp(250, 3000);
-        let mut live_text_segment_emitted = false;
-        let mut live_text_vad = LiveTextVad::new();
-        let mut live_text_silence_start: Option<std::time::Instant> = None;
+        let mut chunker = chunk_cfg
+            .map(|(tx, arm_secs)| Chunker::new(tx, sample_rate, chunk_silence_ms, arm_secs));
 
         while let Ok(mono) = rx.recv() {
             if !local_limit_triggered
@@ -344,13 +335,10 @@ fn spawn_writer_thread(
                 }
             }
 
-            // Standard chunking feeds the chunker and the preview buffer in
-            // parallel. Live text never consumes the streaming buffer (no
-            // preview), so it is skipped to avoid unbounded growth.
             if let Some(chunker) = chunker.as_mut() {
                 chunker.push_samples(&mono);
             }
-            if !is_live_text && !mono.is_empty() {
+            if !mono.is_empty() {
                 streaming_buffer.lock().extend_from_slice(&mono);
             }
 
@@ -370,13 +358,7 @@ fn spawn_writer_thread(
                         let _ = overlay_window.emit("mic-level", ema_level);
                     }
 
-                    // Live text ends on a stop wake word, never on silence,
-                    // so the silence auto-stop is disabled while it is active.
-                    if is_wake_word
-                        && !is_live_text
-                        && !silence_auto_stop_triggered
-                        && silence_auto_stop_ms > 0
-                    {
+                    if is_wake_word && !silence_auto_stop_triggered && silence_auto_stop_ms > 0 {
                         if rms >= SILENCE_AUTO_STOP_SPEECH_THRESHOLD {
                             if !has_speech_started {
                                 info!("Wake word auto-stop: speech detected (rms={:.4})", rms);
@@ -408,32 +390,6 @@ fn spawn_writer_thread(
                             } else {
                                 silence_start = None;
                             }
-                        }
-                    }
-
-                    if is_live_text && !live_text_segment_emitted {
-                        match live_text_vad.update(rms) {
-                            LiveTextSilence::Silent => {
-                                let start = live_text_silence_start
-                                    .get_or_insert_with(std::time::Instant::now);
-                                if start.elapsed()
-                                    >= std::time::Duration::from_millis(live_text_silence_ms)
-                                {
-                                    live_text_segment_emitted = true;
-                                    info!(
-                                        "Live text: segment boundary after {}ms silence",
-                                        live_text_silence_ms
-                                    );
-                                    let app = app.clone();
-                                    std::thread::spawn(move || {
-                                        super::flush_and_continue_live_text(&app);
-                                    });
-                                }
-                            }
-                            LiveTextSilence::Active => {
-                                live_text_silence_start = None;
-                            }
-                            LiveTextSilence::NotStarted => {}
                         }
                     }
 

--- a/src-tauri/src/audio/streaming.rs
+++ b/src-tauri/src/audio/streaming.rs
@@ -157,11 +157,6 @@ impl StreamingVadState {
 }
 
 pub fn start_streaming(app: &AppHandle, audio_state: &AudioState, sample_rate: u32) {
-    if audio_state.live_text_active.load(Ordering::SeqCst) {
-        debug!("start_streaming skipped: live text active (no preview)");
-        return;
-    }
-
     let settings = crate::settings::load_settings(app);
     if !settings.streaming_preview {
         return;

--- a/src-tauri/src/audio/types.rs
+++ b/src-tauri/src/audio/types.rs
@@ -30,8 +30,6 @@ pub struct AudioState {
     pub streaming_buffer: Arc<Mutex<Vec<f32>>>,
     /// The chunking pipeline of the active session
     pub chunk_pipeline: Mutex<Option<ChunkPipeline>>,
-    /// True while a live text session is active (writes on each silence).
-    pub live_text_active: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,7 +82,6 @@ impl AudioState {
             streaming_stop: Arc::new(AtomicBool::new(false)),
             streaming_buffer: Arc::new(Mutex::new(Vec::new())),
             chunk_pipeline: Mutex::new(None),
-            live_text_active: Arc::new(AtomicBool::new(false)),
         }
     }
 

--- a/src-tauri/src/smartmic/audio_bridge.rs
+++ b/src-tauri/src/smartmic/audio_bridge.rs
@@ -1,7 +1,7 @@
 use crate::audio::helpers::resample;
 
-/// Maximum recording samples: 5 minutes at 16 kHz
-const MAX_RECORDING_SAMPLES: usize = 4_800_000;
+const SMARTMIC_CHUNK_SAMPLES: usize = 960_000;
+const SMARTMIC_MAX_SAMPLES: usize = 19_200_000;
 
 /// Accumulate raw PCM bytes (Int16 LE) into the buffer.
 /// Returns `true` if samples were added, `false` if the buffer is full.
@@ -9,7 +9,7 @@ pub fn accumulate_pcm(buffer: &mut Vec<i16>, payload: &[u8]) -> bool {
     // Each sample is 2 bytes (Int16 LE)
     let sample_count = payload.len() / 2;
 
-    if buffer.len() + sample_count > MAX_RECORDING_SAMPLES {
+    if buffer.len() + sample_count > SMARTMIC_MAX_SAMPLES {
         return false;
     }
 
@@ -37,6 +37,13 @@ pub fn finalize_buffer(buffer: Vec<i16>, source_sample_rate: u32) -> Vec<f32> {
     } else {
         samples_f32
     }
+}
+
+pub fn split_into_chunks(buffer: Vec<i16>, source_sample_rate: u32) -> Vec<Vec<f32>> {
+    buffer
+        .chunks(SMARTMIC_CHUNK_SAMPLES)
+        .map(|c| finalize_buffer(c.to_vec(), source_sample_rate))
+        .collect()
 }
 
 /// Calculate the RMS (Root Mean Square) level of the given samples, normalized to 0.0-1.0

--- a/src-tauri/src/smartmic/websocket.rs
+++ b/src-tauri/src/smartmic/websocket.rs
@@ -190,15 +190,12 @@ pub async fn handle_websocket(
                             let accepted = audio_bridge::accumulate_pcm(&mut buffer, payload);
 
                             if !accepted {
-                                // Buffer full - stop recording and notify client
                                 drop(buffer);
                                 is_recording = false;
-                                let err_msg = ServerMessage::Error {
-                                    message: "Recording buffer full (max 5 minutes)".to_string(),
-                                };
-                                let _ = tx.try_send(err_msg.to_json());
+                                finalize_and_process(&app, &state, &tx);
                                 let status_msg = ServerMessage::Status { recording: false };
                                 let _ = tx.try_send(status_msg.to_json());
+                                crate::audio::notify_recording_limit(&app);
                             } else {
                                 // Send mic level periodically (every 100ms max)
                                 if last_mic_level_time.elapsed() >= std::time::Duration::from_millis(100) {
@@ -320,49 +317,7 @@ async fn handle_client_message(
             let status_msg = ServerMessage::Status { recording: false };
             let _ = tx.try_send(status_msg.to_json());
 
-            // Take buffer and process
-            let buffer: Vec<i16> = {
-                let mut buf = state.recording_buffer.lock();
-                std::mem::take(&mut *buf)
-            };
-
-            let smartmic_mode = {
-                let mode = state.recording_mode.lock();
-                mode.clone()
-            };
-
-            let sample_rate = {
-                let sr = state.sample_rate.lock();
-                *sr
-            };
-
-            if buffer.is_empty() {
-                info!("SmartMic recording stopped with empty buffer, skipping transcription");
-                return;
-            }
-
-            info!(
-                "SmartMic recording stopped, processing {} samples (mode: {:?})",
-                buffer.len(),
-                smartmic_mode
-            );
-
-            let app_clone = app.clone();
-            let tx_clone = tx.clone();
-            let should_paste = state
-                .paste_enabled
-                .load(std::sync::atomic::Ordering::SeqCst);
-
-            tokio::task::spawn_blocking(move || {
-                process_recording(
-                    app_clone,
-                    tx_clone,
-                    buffer,
-                    smartmic_mode,
-                    sample_rate,
-                    should_paste,
-                );
-            });
+            finalize_and_process(app, state, tx);
         }
         ClientMessage::RecCancel => {
             *is_recording = false;
@@ -424,6 +379,55 @@ fn lang_code_to_name(code: &str) -> &'static str {
     }
 }
 
+fn finalize_and_process(
+    app: &Arc<tauri::AppHandle>,
+    state: &SmartMicState,
+    tx: &mpsc::Sender<String>,
+) {
+    let buffer: Vec<i16> = {
+        let mut buf = state.recording_buffer.lock();
+        std::mem::take(&mut *buf)
+    };
+
+    if buffer.is_empty() {
+        info!("SmartMic recording stopped with empty buffer, skipping transcription");
+        return;
+    }
+
+    let smartmic_mode = {
+        let mode = state.recording_mode.lock();
+        mode.clone()
+    };
+
+    let sample_rate = {
+        let sr = state.sample_rate.lock();
+        *sr
+    };
+
+    info!(
+        "SmartMic recording stopped, processing {} samples (mode: {:?})",
+        buffer.len(),
+        smartmic_mode
+    );
+
+    let app_clone = app.clone();
+    let tx_clone = tx.clone();
+    let should_paste = state
+        .paste_enabled
+        .load(std::sync::atomic::Ordering::SeqCst);
+
+    tokio::task::spawn_blocking(move || {
+        process_recording(
+            app_clone,
+            tx_clone,
+            buffer,
+            smartmic_mode,
+            sample_rate,
+            should_paste,
+        );
+    });
+}
+
 /// Process a completed SmartMic recording: resample, transcribe, optionally paste, and notify.
 fn process_recording(
     app: Arc<tauri::AppHandle>,
@@ -433,7 +437,7 @@ fn process_recording(
     sample_rate: u32,
     should_paste: bool,
 ) {
-    let samples = audio_bridge::finalize_buffer(buffer, sample_rate);
+    let chunks = audio_bridge::split_into_chunks(buffer, sample_rate);
 
     // For Translation mode: always transcribe in Standard mode first
     let recording_mode = match &mode {
@@ -456,39 +460,49 @@ fn process_recording(
         return;
     }
 
-    match crate::audio::pipeline::process_recording_from_samples(&app, samples, recording_mode) {
-        Ok(text) => {
-            debug!("SmartMic transcription result: {}", text);
-
-            let trans_msg = match &mode {
-                SmartMicMode::Translation { lang_a, lang_b } => {
-                    build_translation_message(&app, text, lang_a, lang_b)
+    let mut parts: Vec<String> = Vec::with_capacity(chunks.len());
+    for samples in chunks {
+        match crate::audio::pipeline::process_recording_from_samples(&app, samples, recording_mode)
+        {
+            Ok(text) => {
+                if !text.is_empty() {
+                    parts.push(text);
                 }
-                _ => {
-                    if !text.is_empty() && should_paste {
-                        if let Err(e) = crate::clipboard::paste(&text, &app) {
-                            warn!("SmartMic: Failed to paste text: {}", e);
-                        }
-                    }
-                    ServerMessage::Transcription {
-                        text,
-                        detected_lang: None,
-                        translated_text: None,
-                        target_lang: None,
-                    }
-                }
-            };
-
-            let _ = tx.try_send(trans_msg.to_json());
-        }
-        Err(e) => {
-            error!("SmartMic transcription failed: {}", e);
-            let err_msg = ServerMessage::Error {
-                message: "Transcription failed".to_string(),
-            };
-            let _ = tx.try_send(err_msg.to_json());
+            }
+            Err(e) => {
+                error!("SmartMic transcription failed: {}", e);
+                let err_msg = ServerMessage::Error {
+                    message: "Transcription failed".to_string(),
+                };
+                let _ = tx.try_send(err_msg.to_json());
+                return;
+            }
         }
     }
+
+    let text = parts.join(" ");
+    debug!("SmartMic transcription result: {}", text);
+
+    let trans_msg = match &mode {
+        SmartMicMode::Translation { lang_a, lang_b } => {
+            build_translation_message(&app, text, lang_a, lang_b)
+        }
+        _ => {
+            if !text.is_empty() && should_paste {
+                if let Err(e) = crate::clipboard::paste(&text, &app) {
+                    warn!("SmartMic: Failed to paste text: {}", e);
+                }
+            }
+            ServerMessage::Transcription {
+                text,
+                detected_lang: None,
+                translated_text: None,
+                target_lang: None,
+            }
+        }
+    };
+
+    let _ = tx.try_send(trans_msg.to_json());
 }
 
 /// Build the server response for a Translation-mode recording. Asks the LLM

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -365,6 +365,7 @@
     "Recent activity": "Activité récente",
     "Recommended": "Recommandé",
     "Record mode": "Mode d'enregistrement",
+    "Recording limited to 20 min": "Enregistrement limité à 20 min",
     "Recording with ": "Recording with ",
     "Refresh": "Refresh",
     "Refresh Models": "Rafraîchir les modèles",

--- a/src/overlay/use-overlay-error.ts
+++ b/src/overlay/use-overlay-error.ts
@@ -1,5 +1,6 @@
 import { listen } from '@tauri-apps/api/event';
 import { useEffect, useState } from 'react';
+import { i18n } from '@/i18n';
 
 const DISMISS_MS = 4000;
 
@@ -16,10 +17,14 @@ export const useOverlayError = () => {
         const unlistenChunkError = listen<string>('transcription-chunk-error', () => {
             setError('Transcription partial');
         });
+        const unlistenLimitReached = listen<string>('recording-limit-reached', () => {
+            setError(i18n.t('Recording limited to 20 min'));
+        });
         return () => {
             unlistenLlmError.then((u) => u());
             unlistenRecordingError.then((u) => u());
             unlistenChunkError.then((u) => u());
+            unlistenLimitReached.then((u) => u());
         };
     }, []);
 


### PR DESCRIPTION
## Description

Route SmartMic and wake word recordings through the same chunked pipeline as standard dictation, fixing FR->EN drift on long recordings and adding a 20 min SmartMic session limit.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement of an existing feature
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] Other: <!-- specify -->

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [ ] I checked for SonarQube issues on the draft PR