### PR TITLE
feat(macos): allow binding the fn / globe key

### DIFF
--- a/src-tauri/src/shortcuts/helpers.rs
+++ b/src-tauri/src/shortcuts/helpers.rs
@@ -38,9 +38,20 @@ fn oem_vk(scan_code: u32, fallback: i32) -> Option<i32> {
     Some(fallback)
 }
 
+/// Synthetic virtual-key code for the macOS fn / globe key.
+///
+/// macOS never exposes fn as a physical keycode readable through
+/// `CGEventSourceKeyState`; it only surfaces as the `kCGEventFlagMaskSecondaryFn`
+/// modifier flag. The value sits above the 8-bit Windows VK range so it cannot
+/// collide with a real VK code.
+#[cfg(target_os = "macos")]
+pub(crate) const VK_FN: i32 = 0x0100;
+
 fn key_name_to_vk(name: &str) -> Option<i32> {
     match name.trim().to_lowercase().as_str() {
         "win" | "meta" | "super" | "command" | "cmd" => Some(0x5B),
+        #[cfg(target_os = "macos")]
+        "fn" | "globe" => Some(VK_FN),
         "ctrl" | "control" => Some(0x11),
         "alt" | "menu" => Some(0x12),
         "shift" => Some(0x10),
@@ -178,6 +189,8 @@ pub(crate) fn vk_to_key_name(vk: i32) -> String {
         0x11 => "ctrl".to_string(),
         0x12 => "alt".to_string(),
         0x10 => "shift".to_string(),
+        #[cfg(target_os = "macos")]
+        VK_FN => "fn".to_string(),
         0x41..=0x5A => {
             let offset = (vk - 0x41) as u8;
             ((b'a' + offset) as char).to_string()
@@ -250,4 +263,17 @@ pub fn keys_to_string(keys: &[i32]) -> String {
         .map(|vk| vk_to_key_name(*vk))
         .collect::<Vec<_>>()
         .join("+")
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::{keys_to_string, parse_binding_keys, VK_FN};
+
+    #[test]
+    fn round_trips_the_fn_key() {
+        assert_eq!(parse_binding_keys("fn"), vec![VK_FN]);
+        assert_eq!(parse_binding_keys("globe"), vec![VK_FN]);
+        assert_eq!(keys_to_string(&[VK_FN]), "fn");
+        assert_eq!(keys_to_string(&parse_binding_keys("fn+space")), "fn+space");
+    }
 }

--- a/src-tauri/src/shortcuts/platform_macos.rs
+++ b/src-tauri/src/shortcuts/platform_macos.rs
@@ -3,6 +3,9 @@
 //! This implementation polls keyboard state using CGEventSourceKeyState
 //! and CGEventSourceFlagsState, similar to the Windows GetAsyncKeyState approach.
 //! This avoids event corruption issues with rdev when enigo simulates key events.
+//!
+//! The fn / globe key is the one exception: it is unreachable by polling and is tracked
+//! by the event tap instead. See [`FN_KEY_DOWN`].
 
 use core_foundation::base::CFRelease;
 use core_foundation::string::UniChar;
@@ -11,6 +14,7 @@ use log::debug;
 use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
 use std::os::raw::c_uint;
+use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -65,6 +69,7 @@ extern "C" {
     ) -> *mut c_void;
     fn CGEventGetIntegerValueField(event: *mut c_void, field: u32) -> i64;
     fn CGEventGetFlags(event: *mut c_void) -> u64;
+    fn CGEventTapEnable(tap: *mut c_void, enable: bool);
     fn CFMachPortCreateRunLoopSource(
         allocator: *mut c_void,
         port: *mut c_void,
@@ -80,6 +85,7 @@ const CG_EVENT_FLAG_MASK_CONTROL: u64 = 0x00040000;
 const CG_EVENT_FLAG_MASK_SHIFT: u64 = 0x00020000;
 const CG_EVENT_FLAG_MASK_ALTERNATE: u64 = 0x00080000;
 const CG_EVENT_FLAG_MASK_COMMAND: u64 = 0x00100000;
+const CG_EVENT_FLAG_MASK_SECONDARY_FN: u64 = 0x00800000;
 
 // Use both session state AND HID state for maximum reliability.
 // Session state (0) can flicker with modal windows, HID state (1) can flicker
@@ -93,6 +99,7 @@ const kCGEventSourceStateHIDSystemState: i32 = 1;
 const MODIFIER_KEYS: &[i32] = &[0x11, 0x10, 0x12, 0x5B];
 
 use crate::shortcuts::accessibility_macos;
+use crate::shortcuts::helpers::VK_FN;
 use crate::shortcuts::registry::ShortcutRegistryState;
 use crate::shortcuts::types::{KeyEventType, ShortcutState};
 
@@ -102,7 +109,29 @@ const K_CG_HEAD_INSERT_EVENT_TAP: u32 = 0;
 const K_CG_EVENT_TAP_OPTION_DEFAULT: u32 = 0;
 const K_CG_EVENT_KEY_DOWN: u64 = 1 << 10;
 const K_CG_EVENT_KEY_UP: u64 = 1 << 11;
+const K_CG_EVENT_FLAGS_CHANGED: u64 = 1 << 12;
 const K_CG_KEYBOARD_EVENT_KEYCODE: u32 = 9;
+
+const EVENT_TYPE_FLAGS_CHANGED: u32 = 12;
+const EVENT_TYPE_TAP_DISABLED_BY_TIMEOUT: u32 = 0xFFFF_FFFE;
+const EVENT_TYPE_TAP_DISABLED_BY_USER_INPUT: u32 = 0xFFFF_FFFF;
+
+/// Physical keycode of the fn / globe key (`kVK_Function`).
+const KEYCODE_FUNCTION: i64 = 63;
+
+/// Live state of the physical fn key, fed by the event tap.
+///
+/// `CGEventSourceFlagsState` cannot be used for this: macOS raises
+/// `kCGEventFlagMaskSecondaryFn` for its own fn-implied combos (arrows, F-keys, delete)
+/// and leaves it raised after the key is released, so the flag says nothing about whether
+/// fn itself is held. Only a `flagsChanged` event carrying keycode 63 does.
+static FN_KEY_DOWN: AtomicBool = AtomicBool::new(false);
+
+/// The running event tap, kept so the callback can re-arm it.
+///
+/// macOS disables a tap whose callback is deemed too slow; since fn detection depends on
+/// this tap, being disabled would silently break fn bindings until the app restarts.
+static EVENT_TAP: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
 
 /// Context passed to the CGEventTap callback for event suppression.
 struct TapContext {
@@ -121,7 +150,32 @@ extern "C" fn suppress_callback(
     event: *mut c_void,
     user_info: *mut c_void,
 ) -> *mut c_void {
+    if event_type == EVENT_TYPE_TAP_DISABLED_BY_TIMEOUT
+        || event_type == EVENT_TYPE_TAP_DISABLED_BY_USER_INPUT
+    {
+        // Events were missed while the tap was off, possibly fn's own key-up: assume released,
+        // otherwise a fn binding could stay stuck down and never stop recording.
+        FN_KEY_DOWN.store(false, Ordering::Relaxed);
+        let tap = EVENT_TAP.load(Ordering::Relaxed);
+        if !tap.is_null() {
+            unsafe { CGEventTapEnable(tap, true) };
+            log::warn!("[macOS shortcuts] Event tap was disabled by the system; re-armed");
+        }
+        return event;
+    }
+
     if user_info.is_null() || event.is_null() {
+        return event;
+    }
+
+    // fn is only observable here: it never reaches CGEventSourceKeyState, and the
+    // SecondaryFn flag alone is raised by other keys too.
+    if event_type == EVENT_TYPE_FLAGS_CHANGED {
+        let keycode = unsafe { CGEventGetIntegerValueField(event, K_CG_KEYBOARD_EVENT_KEYCODE) };
+        if keycode == KEYCODE_FUNCTION {
+            let down = unsafe { CGEventGetFlags(event) } & CG_EVENT_FLAG_MASK_SECONDARY_FN != 0;
+            FN_KEY_DOWN.store(down, Ordering::Relaxed);
+        }
         return event;
     }
 
@@ -216,16 +270,20 @@ fn start_event_suppressor(app: &AppHandle, keycode_map: &HashMap<i32, u16>) {
             K_CG_SESSION_EVENT_TAP,
             K_CG_HEAD_INSERT_EVENT_TAP,
             K_CG_EVENT_TAP_OPTION_DEFAULT,
-            K_CG_EVENT_KEY_DOWN | K_CG_EVENT_KEY_UP,
+            K_CG_EVENT_KEY_DOWN | K_CG_EVENT_KEY_UP | K_CG_EVENT_FLAGS_CHANGED,
             suppress_callback,
             ctx_ptr,
         );
 
         if tap.is_null() {
-            log::warn!("[macOS shortcuts] Could not create CGEventTap for event suppression");
+            log::warn!(
+                "[macOS shortcuts] Could not create CGEventTap: no alert-sound suppression, \
+                 and shortcuts bound to fn will not fire"
+            );
             let _ = Box::from_raw(ctx_ptr as *mut TapContext);
             return;
         }
+        EVENT_TAP.store(tap, Ordering::Relaxed);
 
         let source = CFMachPortCreateRunLoopSource(std::ptr::null_mut(), tap, 0);
         if source.is_null() {
@@ -456,6 +514,9 @@ fn is_modifier_pressed(vk: i32) -> bool {
     let session_flags = unsafe { CGEventSourceFlagsState(kCGEventSourceStateCombinedSessionState) };
     let hid_flags = unsafe { CGEventSourceFlagsState(kCGEventSourceStateHIDSystemState) };
     let flags = session_flags | hid_flags;
+    if vk == VK_FN {
+        return FN_KEY_DOWN.load(Ordering::Relaxed);
+    }
     match vk {
         0x11 => flags & CG_EVENT_FLAG_MASK_CONTROL != 0,
         0x10 => flags & CG_EVENT_FLAG_MASK_SHIFT != 0,
@@ -466,7 +527,7 @@ fn is_modifier_pressed(vk: i32) -> bool {
 }
 
 fn is_key_pressed(vk: i32, keycode_map: &HashMap<i32, u16>) -> bool {
-    if MODIFIER_KEYS.contains(&vk) {
+    if MODIFIER_KEYS.contains(&vk) || vk == VK_FN {
         return is_modifier_pressed(vk);
     }
     // Mouse buttons (CGMouseButton: 0=Left, 1=Right, 2=Middle, 3=Back, 4=Forward)
@@ -523,7 +584,7 @@ fn scan_pressed_vks(keycode_map: &HashMap<i32, u16>) -> HashSet<i32> {
         }
     }
 
-    for vk in [0x02, 0x04, 0x05, 0x06] {
+    for vk in [0x02, 0x04, 0x05, 0x06, VK_FN] {
         if is_key_pressed(vk, keycode_map) {
             pressed.insert(vk);
         }
@@ -543,6 +604,15 @@ fn scan_pressed_vks(keycode_map: &HashMap<i32, u16>) -> HashSet<i32> {
     }
 
     pressed
+}
+
+/// True when fn is the only key currently held.
+///
+/// fn is a prefix for system combos (fn+arrows to page, fn+F-keys for brightness, fn+delete),
+/// so a binding made of fn alone must stay inert unless fn is the only key down — otherwise
+/// paging or changing brightness would also start a recording.
+fn fn_is_held_alone(keycode_map: &HashMap<i32, u16>) -> bool {
+    !scan_pressed_vks(keycode_map).iter().any(|&vk| vk != VK_FN)
 }
 
 pub fn init(app: AppHandle) {
@@ -628,6 +698,10 @@ pub fn init(app: AppHandle) {
 
                 if all_pressed && !extra_modifier_pressed && !active_bindings.contains(&i) {
                     if last_press_times[i].elapsed() < Duration::from_millis(150) {
+                        continue;
+                    }
+
+                    if binding.keys.as_slice() == [VK_FN] && !fn_is_held_alone(&keycode_map) {
                         continue;
                     }
 


### PR DESCRIPTION
Closes #398.

Lets macOS users bind `fn` (the 🌐 key) as a shortcut — the key most people coming from Wispr Flow expect for push-to-talk.

The test matrix below is complete and green on macOS. Still a draft so you can weigh in on the key representation before I mark it ready.

## Why the obvious approach doesn't work

`fn` is never exposed as a physical keycode — `CGEventSourceKeyState(state, 63)` (`kVK_Function`) always reports `false`, so the keycode-map path can't see it. (Same reason Carbon's `RegisterEventHotKey`, and therefore `tauri-plugin-global-shortcut`, can never bind it. This crate's own polling implementation is what makes it possible at all.)

The natural fallback is to read `kCGEventFlagMaskSecondaryFn` from `CGEventSourceFlagsState`, next to the existing ctrl/shift/alt/cmd handling. **That fails, and it fails harmfully.** I built it that way first and ran it on my own machine before measuring properly:

```
flag=1  ks63=0  arrow=1   flags=0xa00100   <- pressing the DOWN arrow raises the fn bit
flag=1  ks63=0  arrow=0   flags=0xa00100   <- the bit stays raised after release
```

Arrow keys and F-keys raise that bit (`0xa00000` = SecondaryFn + NumericPad) and it stays **latched** after release. With a `fn`-only binding the result is a recording that starts on an arrow press and then never stops, because "all keys released" never becomes true again. A guard requiring "fn is the only key held" does not rescue it either: once the arrow is released the guard passes while the flag is still latched.

## What this PR does instead

Track the physical key from the event tap: add `kCGEventFlagsChanged` to the existing tap's mask and update an `AtomicBool` **only** when the event carries keycode 63. That isolates the real fn key and is immune to arrows and F-keys.

One consequence worth calling out: the tap becomes load-bearing instead of cosmetic, so it now re-arms itself on `kCGEventTapDisabledByTimeout` / `ByUserInput`. Without that, macOS disabling the tap would silently break fn bindings until restart. Since events are missed while the tap is off — possibly fn's own key-up — the same branch resets the state to "not held", so a fn binding cannot stay stuck down and record forever.

An earlier revision instead cross-checked the tap state against the SecondaryFn flag on every poll. That worked, but it meant two sources of truth for one fact, and the flag is exactly the signal this PR argues is unreliable. Resetting on re-arm handles the same failure at the point where it happens, with one source of truth and less code.

## Your two constraints

**Nothing changes for Windows and Linux.** This holds by construction, not by testing — which matters since I can only test macOS:

- `platform_macos.rs` is only compiled on macOS via `mod.rs`.
- Every addition to `helpers.rs` is under `#[cfg(target_os = "macos")]`, including the constant, both match arms, and the test module. On Windows and Linux the preprocessor removes all of it.
- No shared, cross-platform or frontend file is touched. The diff is 2 files.

**Minimal.** No drive-by cleanups; existing magic numbers and comments are left exactly as they were.

I did drop one thing during review: pushing `VK_FN` into the suppressor's `pressed_vks`. Because `all_match` is a subset test, a `fn`-only binding would then match while fn+arrow was held and swallow the arrow's `keyDown` — breaking fn+↓ page-down and fn+F1 brightness. The gain was only alert-sound suppression for `fn+X` bindings; not worth a functional regression on the main use case.

## Representation of the key

`fn` has no Windows VK code — on a PC the key is handled in keyboard firmware and never reaches the Win32 API — so there is no real code to reuse. It's represented as a synthetic `VK_FN = 0x0100`, deliberately above the 8-bit VK range so it cannot collide, following the existing precedent in this file where mouse buttons live in `keys` as VK codes and are special-cased in `is_key_pressed` to read a different API.

Worth naming the limitation: the canonical key vocabulary is borrowed from one of the three platforms rather than being neutral, so anything that exists on macOS or Linux but not Windows has no honest representation. A neutral key enum would fix that properly — `tao::KeyCode::Fn` already exists in the dependency tree. I deliberately did not go there: it would touch all three platform modules and the persisted settings format (shortcuts are stored as strings), which is the opposite of what you asked for here. Happy to open a separate discussion if you ever want it.

## Test matrix (macOS 15, Apple Silicon, release build)

- [x] `fn` bound → hold, speak, release → transcription lands. `Binding: action=StartRecording, keys=[256]` in the log.
- [x] No spurious triggers in the log during normal use.
- [x] `arrowdown` bound as a shortcut still fires (no regression for arrow-key users): `keys=[40]`, press/release, transcription lands.
- [x] With `fn` bound, fn+↓ still pages and fn+F1 still changes brightness.
- [x] With `fn` bound, tapping arrows triggers nothing.
- [x] `Event tap was disabled by the system` never logged across the whole session.

Two things I cannot verify myself, stated plainly: I never compiled for Windows or Linux, so the no-impact claim there rests on the `cfg` gating being read, not on a build; and I only have an Apple internal keyboard, so the third-party-keyboard caveat below is reasoning, not measurement.

Checks that pass: `cargo check`, `cargo clippy` (no new warnings), `cargo fmt`, `cargo test` (added a round-trip test on the binding parser), `eslint`, `prettier`.

## Notes for the docs, not code

- The 🌐 key's default system action (emoji picker / input source) has to be set to "Do Nothing" in System Settings → Keyboard, otherwise it fires alongside the recording. The tap can't suppress that reliably — the system handles the globe key upstream.
- Double-pressing `fn` triggers Dictation by default.
- On third-party non-Apple keyboards `fn` is handled in firmware and never reaches macOS, so this only works with Apple keyboards.
