### PR TITLE
fix(api): transcribe audio of any length and cancel on client disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ See [CHANGELOG.md](./CHANGELOG.md).
 - [x] fix(insert): Type accented characters natively in Direct mode on Wayland (extend the XKB char map to real layout keys, AltGr and dead keys) instead of ASCII folding https://github.com/Kieirra/murmure/issues/384
 - [x] fix(llm): Allow typing a custom model name and stop the connection test from locking the Remote provider, so OpenAI compatible servers without a /models endpoint (such as the Claude API) can be used https://github.com/Kieirra/murmure/issues/397
 - [ ] feat(audio): Lower output volume while recording https://github.com/Kieirra/murmure/issues/364
-- [x] fix(api): Route /api/transcribe through the same chunked transcription path as the keyboard and the CLI, so audio of any length works and no duration limit has to be handled https://github.com/Kieirra/murmure/issues/401
+- [x] fix(api): Route /api/transcribe through the same chunked transcription path as the keyboard and the CLI, so audio of any length works and the only limit left is the 100 MB request size, not the audio duration https://github.com/Kieirra/murmure/issues/401
+- [x] feat(api): Cancel the running transcription when the client closes the HTTP connection, and free the queue as soon as the abandoned work has actually stopped https://github.com/Kieirra/murmure/discussions/411
 - [ ] feat(packaging): Investigate adding an AUR package for Arch-based distros (CachyOS) https://github.com/Kieirra/murmure/issues/358#issuecomment-4811232712
 
 ### Backlog

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See [CHANGELOG.md](./CHANGELOG.md).
 - [x] fix(insert): Type accented characters natively in Direct mode on Wayland (extend the XKB char map to real layout keys, AltGr and dead keys) instead of ASCII folding https://github.com/Kieirra/murmure/issues/384
 - [x] fix(llm): Allow typing a custom model name and stop the connection test from locking the Remote provider, so OpenAI compatible servers without a /models endpoint (such as the Claude API) can be used https://github.com/Kieirra/murmure/issues/397
 - [ ] feat(audio): Lower output volume while recording https://github.com/Kieirra/murmure/issues/364
-- [ ] fix(api): Route /api/transcribe through the same chunked transcription path as the keyboard and the CLI, so audio of any length works and no duration limit has to be handled https://github.com/Kieirra/murmure/issues/401
+- [x] fix(api): Route /api/transcribe through the same chunked transcription path as the keyboard and the CLI, so audio of any length works and no duration limit has to be handled https://github.com/Kieirra/murmure/issues/401
 - [ ] feat(packaging): Investigate adding an AUR package for Arch-based distros (CachyOS) https://github.com/Kieirra/murmure/issues/358#issuecomment-4811232712
 
 ### Backlog

--- a/docs/features/api.fr.md
+++ b/docs/features/api.fr.md
@@ -88,15 +88,16 @@ curl -X POST http://127.0.0.1:4800/api/transcribe \
 
 ## Limitations
 
-| Contrainte            | Valeur                                        |
-| --------------------- | --------------------------------------------- |
-| Format audio          | WAV uniquement                                |
-| Taille max            | 100 Mo                                        |
-| Frequence optimale    | 16kHz mono (les autres sont reechantillonnes) |
-| Streaming temps reel  | Non supporte                                  |
-| Requetes concurrentes | Sequentielles uniquement                      |
-| Acces reseau          | localhost / 127.0.0.1 uniquement              |
-| CORS                  | Desactive                                     |
+| Contrainte            | Valeur                                                                                                                                   |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Format audio          | WAV uniquement                                                                                                                           |
+| Taille max            | 100 Mo                                                                                                                                   |
+| Duree audio           | Aucune limite. Bornee uniquement par les 100 Mo du corps de requete, soit environ 52 min de WAV mono 16 kHz ou 17 min de WAV mono 48 kHz |
+| Frequence optimale    | 16kHz mono (les autres sont reechantillonnes)                                                                                            |
+| Streaming temps reel  | Non supporte                                                                                                                             |
+| Requetes concurrentes | Sequentielles uniquement                                                                                                                 |
+| Acces reseau          | localhost / 127.0.0.1 uniquement                                                                                                         |
+| CORS                  | Desactive                                                                                                                                |
 
 ## Notes
 
@@ -104,3 +105,6 @@ curl -X POST http://127.0.0.1:4800/api/transcribe \
 - La langue est detectee automatiquement
 - La premiere requete est plus lente (chargement du modele)
 - Le port est configurable entre 1024 et 65535
+- Un audio long est decoupe en segments avant transcription, exactement comme le font le raccourci clavier et la CLI. Il n'y a aucune limite de duree.
+- La reponse est synchrone. Un fichier long garde la connexion ouverte plusieurs minutes, desactivez donc le timeout de votre client HTTP.
+- Le nettoyage des tics de langage et les regles de formatage sont appliques au resultat, l'API renvoie donc le meme texte que le raccourci clavier pour un meme audio.

--- a/docs/features/api.fr.md
+++ b/docs/features/api.fr.md
@@ -88,16 +88,17 @@ curl -X POST http://127.0.0.1:4800/api/transcribe \
 
 ## Limitations
 
-| Contrainte            | Valeur                                                                                                                                   |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Format audio          | WAV uniquement                                                                                                                           |
-| Taille max            | 100 Mo                                                                                                                                   |
-| Duree audio           | Aucune limite. Bornee uniquement par les 100 Mo du corps de requete, soit environ 52 min de WAV mono 16 kHz ou 17 min de WAV mono 48 kHz |
-| Frequence optimale    | 16kHz mono (les autres sont reechantillonnes)                                                                                            |
-| Streaming temps reel  | Non supporte                                                                                                                             |
-| Requetes concurrentes | Sequentielles uniquement                                                                                                                 |
-| Acces reseau          | localhost / 127.0.0.1 uniquement                                                                                                         |
-| CORS                  | Desactive                                                                                                                                |
+| Contrainte            | Valeur                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Format audio          | WAV uniquement                                                                                                      |
+| Taille max            | 100 Mo                                                                                                              |
+| Duree audio           | Aucune limite, seule la taille de 100 Mo s'applique                                                                 |
+| Annulation            | Fermez la connexion. L'arret intervient a la fin du segment audio en cours                                          |
+| Frequence optimale    | 16kHz mono (les autres sont reechantillonnes)                                                                       |
+| Streaming temps reel  | Non supporte                                                                                                        |
+| Requetes concurrentes | Sequentielles uniquement (file d'attente). Une requete annulee libere sa place des qu'elle s'est reellement arretee |
+| Acces reseau          | localhost / 127.0.0.1 uniquement                                                                                    |
+| CORS                  | Desactive                                                                                                           |
 
 ## Notes
 
@@ -106,5 +107,5 @@ curl -X POST http://127.0.0.1:4800/api/transcribe \
 - La premiere requete est plus lente (chargement du modele)
 - Le port est configurable entre 1024 et 65535
 - Un audio long est decoupe en segments avant transcription, exactement comme le font le raccourci clavier et la CLI. Il n'y a aucune limite de duree.
-- La reponse est synchrone. Un fichier long garde la connexion ouverte plusieurs minutes, desactivez donc le timeout de votre client HTTP.
+- La reponse est synchrone. Un fichier long garde la connexion ouverte plusieurs minutes, desactivez donc le timeout de votre client HTTP ou reglez-le bien au-dela de la duree attendue : un timeout qui expire annule la transcription.
 - Le nettoyage des tics de langage et les regles de formatage sont appliques au resultat, l'API renvoie donc le meme texte que le raccourci clavier pour un meme audio.

--- a/docs/features/api.md
+++ b/docs/features/api.md
@@ -88,15 +88,16 @@ curl -X POST http://127.0.0.1:4800/api/transcribe \
 
 ## Limitations
 
-| Constraint          | Value                             |
-| ------------------- | --------------------------------- |
-| Audio format        | WAV only                          |
-| Max file size       | 100 MB                            |
-| Optimal sample rate | 16kHz mono (others are resampled) |
-| Real-time streaming | Not supported                     |
-| Concurrent requests | Sequential only (queued)          |
-| Network access      | localhost / 127.0.0.1 only        |
-| CORS                | Disabled                          |
+| Constraint          | Value                                                                                                        |
+| ------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Audio format        | WAV only                                                                                                     |
+| Max file size       | 100 MB                                                                                                       |
+| Audio length        | No limit. Bounded only by the 100 MB body size, about 52 min of 16 kHz mono WAV or 17 min of 48 kHz mono WAV |
+| Optimal sample rate | 16kHz mono (others are resampled)                                                                            |
+| Real-time streaming | Not supported                                                                                                |
+| Concurrent requests | Sequential only (queued)                                                                                     |
+| Network access      | localhost / 127.0.0.1 only                                                                                   |
+| CORS                | Disabled                                                                                                     |
 
 ## Notes
 
@@ -104,3 +105,6 @@ curl -X POST http://127.0.0.1:4800/api/transcribe \
 - Language is auto-detected (no way to force a language)
 - The first request is slower (model warmup)
 - The port can be configured between 1024 and 65535
+- Long audio is split into segments before transcription, the same way the keyboard shortcut and the CLI do it. There is no duration limit.
+- The response is synchronous. A long file keeps the connection open for several minutes, so disable the timeout in your HTTP client.
+- Filler removal and formatting rules are applied to the result, so the API returns the same text as the keyboard shortcut for the same audio.

--- a/docs/features/api.md
+++ b/docs/features/api.md
@@ -88,16 +88,17 @@ curl -X POST http://127.0.0.1:4800/api/transcribe \
 
 ## Limitations
 
-| Constraint          | Value                                                                                                        |
-| ------------------- | ------------------------------------------------------------------------------------------------------------ |
-| Audio format        | WAV only                                                                                                     |
-| Max file size       | 100 MB                                                                                                       |
-| Audio length        | No limit. Bounded only by the 100 MB body size, about 52 min of 16 kHz mono WAV or 17 min of 48 kHz mono WAV |
-| Optimal sample rate | 16kHz mono (others are resampled)                                                                            |
-| Real-time streaming | Not supported                                                                                                |
-| Concurrent requests | Sequential only (queued)                                                                                     |
-| Network access      | localhost / 127.0.0.1 only                                                                                   |
-| CORS                | Disabled                                                                                                     |
+| Constraint          | Value                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------- |
+| Audio format        | WAV only                                                                                  |
+| Max file size       | 100 MB                                                                                    |
+| Audio length        | No limit, only the 100 MB file size applies                                               |
+| Cancellation        | Close the connection. Stops at the end of the current audio segment                       |
+| Optimal sample rate | 16kHz mono (others are resampled)                                                         |
+| Real-time streaming | Not supported                                                                             |
+| Concurrent requests | Sequential only (queued). A cancelled request frees its slot once it has actually stopped |
+| Network access      | localhost / 127.0.0.1 only                                                                |
+| CORS                | Disabled                                                                                  |
 
 ## Notes
 
@@ -106,5 +107,5 @@ curl -X POST http://127.0.0.1:4800/api/transcribe \
 - The first request is slower (model warmup)
 - The port can be configured between 1024 and 65535
 - Long audio is split into segments before transcription, the same way the keyboard shortcut and the CLI do it. There is no duration limit.
-- The response is synchronous. A long file keeps the connection open for several minutes, so disable the timeout in your HTTP client.
+- The response is synchronous. A long file keeps the connection open for several minutes, so disable the timeout in your HTTP client or set it well above the expected duration: a timeout that fires cancels the transcription.
 - Filler removal and formatting rules are applied to the result, so the API returns the same text as the keyboard shortcut for the same audio.

--- a/src-tauri/src/audio/chunking.rs
+++ b/src-tauri/src/audio/chunking.rs
@@ -93,10 +93,18 @@ pub struct ChunkPipeline {
 
 impl ChunkPipeline {
     pub fn start(app: &AppHandle, preview: Option<PreviewLink>) -> Self {
+        let epoch = PIPELINE_EPOCH.fetch_add(1, Ordering::SeqCst) + 1;
+        Self::start_inner(app, preview, Some(epoch))
+    }
+
+    pub fn start_headless(app: &AppHandle) -> Self {
+        Self::start_inner(app, None, None)
+    }
+
+    fn start_inner(app: &AppHandle, preview: Option<PreviewLink>, epoch: Option<u64>) -> Self {
         let (tx, rx) = mpsc::channel::<ChunkJob>();
         let accumulated = Arc::new(Mutex::new(String::new()));
         let cancelled = Arc::new(AtomicBool::new(false));
-        let epoch = PIPELINE_EPOCH.fetch_add(1, Ordering::SeqCst) + 1;
         let worker = spawn_worker(
             app.clone(),
             rx,
@@ -147,12 +155,14 @@ fn spawn_worker(
     accumulated: Arc<Mutex<String>>,
     preview: Option<PreviewLink>,
     cancelled: Arc<AtomicBool>,
-    epoch: u64,
+    epoch: Option<u64>,
 ) -> JoinHandle<()> {
     std::thread::spawn(move || {
         let freeze_settings = preview.as_ref().map(|_| load_formatting_settings(&app));
-        let owns_ui =
-            || !cancelled.load(Ordering::SeqCst) && PIPELINE_EPOCH.load(Ordering::SeqCst) == epoch;
+        let owns_ui = || {
+            !cancelled.load(Ordering::SeqCst)
+                && epoch.is_some_and(|e| PIPELINE_EPOCH.load(Ordering::SeqCst) == e)
+        };
         let mut expected_seq: u64 = 0;
         while let Ok(job) = rx.recv() {
             match job {

--- a/src-tauri/src/audio/chunking.rs
+++ b/src-tauri/src/audio/chunking.rs
@@ -94,17 +94,21 @@ pub struct ChunkPipeline {
 impl ChunkPipeline {
     pub fn start(app: &AppHandle, preview: Option<PreviewLink>) -> Self {
         let epoch = PIPELINE_EPOCH.fetch_add(1, Ordering::SeqCst) + 1;
-        Self::start_inner(app, preview, Some(epoch))
+        Self::start_inner(app, preview, Some(epoch), Arc::new(AtomicBool::new(false)))
     }
 
-    pub fn start_headless(app: &AppHandle) -> Self {
-        Self::start_inner(app, None, None)
+    pub fn start_headless(app: &AppHandle, cancelled: Arc<AtomicBool>) -> Self {
+        Self::start_inner(app, None, None, cancelled)
     }
 
-    fn start_inner(app: &AppHandle, preview: Option<PreviewLink>, epoch: Option<u64>) -> Self {
+    fn start_inner(
+        app: &AppHandle,
+        preview: Option<PreviewLink>,
+        epoch: Option<u64>,
+        cancelled: Arc<AtomicBool>,
+    ) -> Self {
         let (tx, rx) = mpsc::channel::<ChunkJob>();
         let accumulated = Arc::new(Mutex::new(String::new()));
-        let cancelled = Arc::new(AtomicBool::new(false));
         let worker = spawn_worker(
             app.clone(),
             rx,
@@ -174,6 +178,10 @@ fn spawn_worker(
                 } => {
                     debug_assert_eq!(seq, expected_seq, "chunk seq must be monotonic");
                     expected_seq = expected_seq.saturating_add(1);
+                    if cancelled.load(Ordering::SeqCst) {
+                        debug!("Chunk pipeline: cancelled, skipping chunk {}", seq);
+                        continue;
+                    }
                     let chunk_secs = samples.len() as f32 / sample_rate.max(1) as f32;
 
                     if let Some(link) = preview.as_ref() {

--- a/src-tauri/src/audio/helpers.rs
+++ b/src-tauri/src/audio/helpers.rs
@@ -126,7 +126,7 @@ pub fn read_wav_samples(wav_path: &Path) -> Result<Vec<f32>> {
     Ok(out)
 }
 
-pub fn read_wav_mono_native(wav_path: &Path) -> Result<(Vec<f32>, u32)> {
+fn read_wav_mono_native(wav_path: &Path) -> Result<(Vec<f32>, u32)> {
     let mut reader = hound::WavReader::open(wav_path)?;
     let spec = reader.spec();
 

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -1,6 +1,6 @@
 use crate::audio::chunking::{ChunkPipeline, Chunker};
 use crate::audio::clean_recording::strip_fillers_and_repeats;
-use crate::audio::helpers::{read_wav_mono_native, read_wav_samples, resample, rms};
+use crate::audio::helpers::{read_wav_samples, resample, rms};
 use crate::audio::types::{AudioState, RecordingMode};
 use crate::dictionary::{correct_transcription, sync_boost_words, Dictionary};
 use crate::engine::transcription_engine::{TranscriptionEngine, TranscriptionResult};
@@ -127,14 +127,14 @@ fn post_process_chunks(
 }
 
 pub fn transcribe_file_chunked(app: &AppHandle, file_path: &Path) -> Result<String> {
-    let (samples, sample_rate) = read_wav_mono_native(file_path)?;
+    let samples = read_wav_samples(file_path)?;
     if samples.is_empty() {
         return Err(anyhow::anyhow!("Audio file contains no samples"));
     }
 
-    let pipeline = ChunkPipeline::start(app, None);
-    let mut chunker = Chunker::new(pipeline.sender(), sample_rate, None);
-    let window = (sample_rate as usize * 33 / 1000).max(1);
+    let pipeline = ChunkPipeline::start_headless(app);
+    let mut chunker = Chunker::new(pipeline.sender(), 16000, None);
+    let window = 16000 * 33 / 1000;
     for win in samples.chunks(window) {
         chunker.push_samples(win);
         chunker.on_throttle_tick(rms(win));
@@ -143,36 +143,7 @@ pub fn transcribe_file_chunked(app: &AppHandle, file_path: &Path) -> Result<Stri
     let accumulated = pipeline.finalize();
 
     let result = post_process_chunks(app, accumulated, RecordingMode::Standard)?;
-    let text = result.text.trim().to_string();
-    if text.is_empty() {
-        return Err(anyhow::anyhow!("Transcription produced no text"));
-    }
-
-    Ok(text)
-}
-
-pub fn transcribe_audio(app: &AppHandle, audio_path: &Path) -> Result<TranscriptionResult> {
-    let _ = app.emit("llm-processing-start", ());
-
-    let state = app.state::<AudioState>();
-    ensure_engine_loaded(app, &state)?;
-
-    let samples = read_wav_samples(audio_path)?;
-
-    let mut engine_guard = state.engine.lock();
-    let engine = engine_guard
-        .as_mut()
-        .ok_or_else(|| anyhow::anyhow!("Engine not loaded"))?;
-
-    sync_boost_words(engine, &app.state::<Dictionary>().get());
-
-    let result = engine.transcribe_samples(samples, None).map_err(|e| {
-        let _ = app.emit("llm-processing-end", ());
-        anyhow::anyhow!("Transcription failed: {}", e)
-    })?;
-    let _ = app.emit("llm-processing-end", ());
-
-    Ok(result)
+    Ok(result.text.trim().to_string())
 }
 
 fn apply_dictionary_correction(

--- a/src-tauri/src/audio/pipeline.rs
+++ b/src-tauri/src/audio/pipeline.rs
@@ -11,6 +11,7 @@ use crate::stats;
 use anyhow::Result;
 use log::{debug, error, info, warn};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -127,12 +128,25 @@ fn post_process_chunks(
 }
 
 pub fn transcribe_file_chunked(app: &AppHandle, file_path: &Path) -> Result<String> {
+    let never_cancelled = Arc::new(AtomicBool::new(false));
+    transcribe_file_chunked_cancellable(app, file_path, &never_cancelled)
+        .map(|text| text.unwrap_or_default())
+}
+
+pub fn transcribe_file_chunked_cancellable(
+    app: &AppHandle,
+    file_path: &Path,
+    cancelled: &Arc<AtomicBool>,
+) -> Result<Option<String>> {
     let samples = read_wav_samples(file_path)?;
     if samples.is_empty() {
         return Err(anyhow::anyhow!("Audio file contains no samples"));
     }
+    if cancelled.load(Ordering::SeqCst) {
+        return Ok(None);
+    }
 
-    let pipeline = ChunkPipeline::start_headless(app);
+    let pipeline = ChunkPipeline::start_headless(app, cancelled.clone());
     let mut chunker = Chunker::new(pipeline.sender(), 16000, None);
     let window = 16000 * 33 / 1000;
     for win in samples.chunks(window) {
@@ -142,8 +156,12 @@ pub fn transcribe_file_chunked(app: &AppHandle, file_path: &Path) -> Result<Stri
     chunker.flush_remaining();
     let accumulated = pipeline.finalize();
 
+    if cancelled.load(Ordering::SeqCst) {
+        return Ok(None);
+    }
+
     let result = post_process_chunks(app, accumulated, RecordingMode::Standard)?;
-    Ok(result.text.trim().to_string())
+    Ok(Some(result.text.trim().to_string()))
 }
 
 fn apply_dictionary_correction(

--- a/src-tauri/src/http_api/server.rs
+++ b/src-tauri/src/http_api/server.rs
@@ -1,8 +1,8 @@
-use super::types::{HttpApiState, TranscribeState};
+use super::types::{CancelOnDrop, HttpApiState, TempWav, TranscribeState};
 use crate::audio;
 use anyhow::Result;
 use axum::{
-    extract::{multipart::Field, DefaultBodyLimit, Multipart},
+    extract::{DefaultBodyLimit, Multipart},
     http::StatusCode,
     response::IntoResponse,
     routing::post,
@@ -11,6 +11,7 @@ use axum::{
 use log::info;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 #[derive(Serialize, Deserialize)]
@@ -68,11 +69,19 @@ async fn transcribe_handler(
     axum::extract::State(state): axum::extract::State<TranscribeState>,
     mut multipart: Multipart,
 ) -> impl IntoResponse {
+    let mut audio_bytes = None;
+
     loop {
         match multipart.next_field().await {
-            Ok(Some(field)) if field.name() == Some("audio") => {
-                return transcribe_field(&state, field).await
-            }
+            Ok(Some(field)) if field.name() == Some("audio") => match field.bytes().await {
+                Ok(b) => audio_bytes = Some(b),
+                Err(e) => {
+                    return error_response(
+                        StatusCode::BAD_REQUEST,
+                        format!("Failed to read audio file: {}", e),
+                    )
+                }
+            },
             Ok(Some(_)) => {}
             Ok(None) => break,
             Err(e) => {
@@ -84,47 +93,79 @@ async fn transcribe_handler(
         }
     }
 
-    error_response(
-        StatusCode::BAD_REQUEST,
-        "No 'audio' field in multipart request".to_string(),
-    )
+    match audio_bytes {
+        Some(bytes) => transcribe_bytes(&state, bytes).await,
+        None => error_response(
+            StatusCode::BAD_REQUEST,
+            "No 'audio' field in multipart request".to_string(),
+        ),
+    }
 }
 
-async fn transcribe_field(state: &TranscribeState, field: Field<'_>) -> axum::response::Response {
-    let bytes = match field.bytes().await {
-        Ok(b) => b,
-        Err(e) => {
-            return error_response(
-                StatusCode::BAD_REQUEST,
-                format!("Failed to read audio file: {}", e),
-            )
-        }
-    };
+async fn transcribe_bytes(
+    state: &TranscribeState,
+    bytes: axum::body::Bytes,
+) -> axum::response::Response {
+    let id = uuid::Uuid::new_v4();
+    let temp = TempWav(std::env::temp_dir().join(format!("murmure-{}.wav", id)));
+    let mut short_id = id.to_string();
+    short_id.truncate(8);
 
-    let temp_path = std::env::temp_dir().join(format!("murmure-{}.wav", uuid::Uuid::new_v4()));
-
-    if let Err(e) = std::fs::write(&temp_path, bytes) {
+    if let Err(e) = std::fs::write(&temp.0, bytes) {
         return error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Failed to write audio file: {}", e),
         );
     }
 
-    let _guard = state.transcribe_lock.lock().await;
+    let transcribe_guard = state.transcribe_lock.clone().lock_owned().await;
+
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let _cancel_on_drop = CancelOnDrop(cancelled.clone());
+
+    info!("HTTP API transcription {}: starting", short_id);
+    let started = std::time::Instant::now();
 
     let app = state.app.clone();
-    let path = temp_path.clone();
+    let cancelled = cancelled.clone();
+    let log_id = short_id.clone();
     let joined = tokio::task::spawn_blocking(move || {
+        // Owning the lock and the temp file here ties them to the real work, not to the connection.
+        let _guard = transcribe_guard;
+        let temp = temp;
+        if cancelled.load(Ordering::SeqCst) {
+            info!(
+                "HTTP API transcription {}: cancelled by client disconnect",
+                log_id
+            );
+            return Ok(None);
+        }
         audio::preload_engine(&app).map_err(|e| format!("Model not available: {}", e))?;
-        audio::transcribe_file_chunked(&app, &path)
-            .map_err(|e| format!("Transcription failed: {}", e))
+        let result = audio::transcribe_file_chunked_cancellable(&app, &temp.0, &cancelled)
+            .map_err(|e| format!("Transcription failed: {}", e))?;
+        if result.is_none() {
+            info!(
+                "HTTP API transcription {}: cancelled by client disconnect",
+                log_id
+            );
+        }
+        Ok(result)
     })
     .await;
 
-    let _ = std::fs::remove_file(&temp_path);
-
     match joined {
-        Ok(Ok(text)) => (StatusCode::OK, Json(TranscriptionResponse { text })).into_response(),
+        Ok(Ok(Some(text))) => {
+            info!(
+                "HTTP API transcription {}: done in {} ms",
+                short_id,
+                started.elapsed().as_millis()
+            );
+            (StatusCode::OK, Json(TranscriptionResponse { text })).into_response()
+        }
+        Ok(Ok(None)) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Transcription cancelled".to_string(),
+        ),
         Ok(Err(e)) => error_response(StatusCode::INTERNAL_SERVER_ERROR, e),
         Err(e) => error_response(
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src-tauri/src/http_api/server.rs
+++ b/src-tauri/src/http_api/server.rs
@@ -1,8 +1,8 @@
+use super::types::{HttpApiState, TranscribeState};
 use crate::audio;
-use crate::dictionary::{correct_transcription, Dictionary};
 use anyhow::Result;
 use axum::{
-    extract::{DefaultBodyLimit, Multipart},
+    extract::{multipart::Field, DefaultBodyLimit, Multipart},
     http::StatusCode,
     response::IntoResponse,
     routing::post,
@@ -12,7 +12,6 @@ use log::info;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tauri::Manager;
 
 #[derive(Serialize, Deserialize)]
 pub struct TranscriptionResponse {
@@ -24,16 +23,23 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
+fn error_response(status: StatusCode, error: String) -> axum::response::Response {
+    (status, Json(ErrorResponse { error })).into_response()
+}
+
 pub async fn start_http_api(
     app: tauri::AppHandle,
     port: u16,
-    api_state: super::types::HttpApiState,
+    api_state: HttpApiState,
 ) -> Result<()> {
-    let app = Arc::new(app);
+    let state = TranscribeState {
+        app: Arc::new(app),
+        transcribe_lock: Arc::new(tokio::sync::Mutex::new(())),
+    };
 
     let router = Router::new()
         .route("/api/transcribe", post(transcribe_handler))
-        .with_state(app.clone())
+        .with_state(state)
         .layer(DefaultBodyLimit::max(100_000_000));
 
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
@@ -59,86 +65,70 @@ pub async fn start_http_api(
 }
 
 async fn transcribe_handler(
-    axum::extract::State(app): axum::extract::State<Arc<tauri::AppHandle>>,
+    axum::extract::State(state): axum::extract::State<TranscribeState>,
     mut multipart: Multipart,
 ) -> impl IntoResponse {
     loop {
         match multipart.next_field().await {
-            Ok(Some(field)) => {
-                if field.name() == Some("audio") {
-                    let bytes = match field.bytes().await {
-                        Ok(b) => b,
-                        Err(e) => {
-                            return (
-                                StatusCode::BAD_REQUEST,
-                                Json(ErrorResponse {
-                                    error: format!("Failed to read audio file: {}", e),
-                                }),
-                            )
-                                .into_response()
-                        }
-                    };
-
-                    let temp_path =
-                        std::env::temp_dir().join(format!("murmure-{}.wav", uuid::Uuid::new_v4()));
-
-                    if let Err(e) = std::fs::write(&temp_path, bytes) {
-                        return (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse {
-                                error: format!("Failed to write audio file: {}", e),
-                            }),
-                        )
-                            .into_response();
-                    }
-
-                    let result = match audio::preload_engine(&app) {
-                        Ok(_) => match audio::transcribe_audio(&app, &temp_path) {
-                            Ok(transcription) => {
-                                let dictionary = app.state::<Dictionary>().get();
-                                Ok(correct_transcription(
-                                    &transcription.text,
-                                    &dictionary,
-                                    &transcription.word_confidences,
-                                ))
-                            }
-                            Err(e) => Err(format!("Transcription failed: {}", e)),
-                        },
-                        Err(e) => Err(format!("Model not available: {}", e)),
-                    };
-
-                    let _ = std::fs::remove_file(&temp_path);
-
-                    return match result {
-                        Ok(text) => {
-                            (StatusCode::OK, Json(TranscriptionResponse { text })).into_response()
-                        }
-                        Err(e) => (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Json(ErrorResponse { error: e }),
-                        )
-                            .into_response(),
-                    };
-                }
+            Ok(Some(field)) if field.name() == Some("audio") => {
+                return transcribe_field(&state, field).await
             }
+            Ok(Some(_)) => {}
             Ok(None) => break,
             Err(e) => {
-                return (
+                return error_response(
                     StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse {
-                        error: format!("Failed to parse multipart: {}", e),
-                    }),
+                    format!("Failed to parse multipart: {}", e),
                 )
-                    .into_response()
             }
         }
     }
 
-    (
+    error_response(
         StatusCode::BAD_REQUEST,
-        Json(ErrorResponse {
-            error: "No 'audio' field in multipart request".to_string(),
-        }),
+        "No 'audio' field in multipart request".to_string(),
     )
-        .into_response()
+}
+
+async fn transcribe_field(state: &TranscribeState, field: Field<'_>) -> axum::response::Response {
+    let bytes = match field.bytes().await {
+        Ok(b) => b,
+        Err(e) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                format!("Failed to read audio file: {}", e),
+            )
+        }
+    };
+
+    let temp_path = std::env::temp_dir().join(format!("murmure-{}.wav", uuid::Uuid::new_v4()));
+
+    if let Err(e) = std::fs::write(&temp_path, bytes) {
+        return error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to write audio file: {}", e),
+        );
+    }
+
+    let _guard = state.transcribe_lock.lock().await;
+
+    let app = state.app.clone();
+    let path = temp_path.clone();
+    let joined = tokio::task::spawn_blocking(move || {
+        audio::preload_engine(&app).map_err(|e| format!("Model not available: {}", e))?;
+        audio::transcribe_file_chunked(&app, &path)
+            .map_err(|e| format!("Transcription failed: {}", e))
+    })
+    .await;
+
+    let _ = std::fs::remove_file(&temp_path);
+
+    match joined {
+        Ok(Ok(text)) => (StatusCode::OK, Json(TranscriptionResponse { text })).into_response(),
+        Ok(Err(e)) => error_response(StatusCode::INTERNAL_SERVER_ERROR, e),
+        Err(e) => error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Transcription task failed: {}", e),
+        ),
+    }
 }

--- a/src-tauri/src/http_api/types.rs
+++ b/src-tauri/src/http_api/types.rs
@@ -1,3 +1,6 @@
+use log::warn;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
 
@@ -5,6 +8,24 @@ use tokio::sync::oneshot;
 pub struct TranscribeState {
     pub app: Arc<tauri::AppHandle>,
     pub transcribe_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+pub(super) struct CancelOnDrop(pub(super) Arc<AtomicBool>);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+pub(super) struct TempWav(pub(super) PathBuf);
+
+impl Drop for TempWav {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.0) {
+            warn!("HTTP API: failed to remove temp audio file: {}", e);
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/src-tauri/src/http_api/types.rs
+++ b/src-tauri/src/http_api/types.rs
@@ -2,6 +2,12 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
 
 #[derive(Clone)]
+pub struct TranscribeState {
+    pub app: Arc<tauri::AppHandle>,
+    pub transcribe_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+#[derive(Clone)]
 pub struct HttpApiState {
     shutdown_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -283,6 +283,10 @@ pub fn run() {
                     app.handle(),
                     std::path::Path::new(file_path),
                 ) {
+                    Ok(text) if text.is_empty() => {
+                        eprintln!("Transcription produced no text");
+                        app.handle().exit(1);
+                    }
                     Ok(text) => {
                         println!("{}", text);
                         app.handle().exit(0);


### PR DESCRIPTION
fix: https://github.com/Kieirra/murmure/issues/401
fix: https://github.com/Kieirra/murmure/discussions/411

## Description

Routes `/api/transcribe` through the same chunked transcription path as the keyboard and the CLI, so audio of any length works, and cancels the running transcription when the client closes the connection, freeing the queue as soon as the abandoned work has actually stopped.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other: <!-- specify -->

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [ ] My PR addresses **one single concern**
- [ ] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [ ] I checked for SonarQube issues on the draft PR
