### PR TITLE
feat: add a pacman package for Arch-based distros

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -164,6 +164,34 @@ jobs:
                   find src-tauri/target/release/bundle -name "*.rpm" ! -name "*.sig" -exec sh -c 'mv "$1" "$(dirname "$1")/Murmure_amd64.rpm"' _ {} \;
                   find src-tauri/target/release/bundle -name "*.rpm.sig" -exec sh -c 'mv "$1" "$(dirname "$1")/Murmure_amd64.rpm.sig"' _ {} \;
 
+            - name: Build Arch package
+              if: ${{ inputs.dry == false }}
+              shell: bash
+              run: |
+                  STAGING="${{ runner.temp }}/archpkg"
+                  mkdir -p "$STAGING"
+                  cp packaging/aur/PKGBUILD packaging/aur/murmure.install "$STAGING/"
+                  cp "$(find src-tauri/target/release/bundle -name 'Murmure_amd64.deb')" "$STAGING/"
+                  VERSION=$(node -p "require('./package.json').version")
+                  sed -i "s/@VERSION@/$VERSION/" "$STAGING/PKGBUILD"
+                  docker run --rm -v "$STAGING":/build archlinux:base-devel bash -c "useradd -m builder && chown -R builder /build && su builder -c 'cd /build && makepkg --noconfirm --nodeps'"
+                  mkdir -p src-tauri/target/release/bundle/pacman
+                  mv "$STAGING"/murmure-*.pkg.tar.zst src-tauri/target/release/bundle/pacman/Murmure_amd64.pkg.tar.zst
+
+            - name: Sign Arch package with Tauri signer
+              if: ${{ inputs.dry == false }}
+              env:
+                  TAURI_PRIVATE_KEY_PATH: tauri.key
+                  TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+              shell: bash
+              run: |
+                  files=$(find src-tauri/target/release/bundle -type f -name "*.pkg.tar.zst")
+                  if [ -n "$files" ]; then
+                    pnpm tauri signer sign $files
+                  else
+                    echo "No pacman package found to sign."
+                  fi
+
             - name: Upload artifact (1 day)
               if: ${{ inputs.dry == false }}
               uses: actions/upload-artifact@v4
@@ -173,5 +201,6 @@ jobs:
                       src-tauri/target/release/bundle/**/*.AppImage
                       src-tauri/target/release/bundle/**/*.deb
                       src-tauri/target/release/bundle/**/*.rpm
+                      src-tauri/target/release/bundle/**/*.pkg.tar.zst
                       src-tauri/target/release/bundle/**/*.sig
                   retention-days: 1

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ See [CHANGELOG.md](./CHANGELOG.md).
 - [x] fix(api): Route /api/transcribe through the same chunked transcription path as the keyboard and the CLI, so audio of any length works and the only limit left is the 100 MB request size, not the audio duration https://github.com/Kieirra/murmure/issues/401
 - [x] feat(api): Cancel the running transcription when the client closes the HTTP connection, and free the queue as soon as the abandoned work has actually stopped https://github.com/Kieirra/murmure/discussions/411
 - [x] fix(audio): Pad each chunk with silence before inference, to fix chunks the model cannot decode, which silently truncated the transcription
-- [ ] feat(packaging): Investigate adding an AUR package for Arch-based distros (CachyOS) https://github.com/Kieirra/murmure/issues/358#issuecomment-4811232712
+- [x] feat(packaging): Add a pacman package for Arch-based distros (CachyOS) to the release, and point the update button to the releases page for those installs, as the Tauri updater has no pacman installer https://github.com/Kieirra/murmure/issues/358#issuecomment-4811232712
+- [ ] feat(cli): Add a --hidden flag to launch Murmure without showing the window, combined with control commands such as --transcription or --llm-mode (replaces the internal --autostart workaround)
 
 ### Backlog
 - [ ] fix(api): Remove the experimental tag and consolidate the API

--- a/docs/getting-started/linux.fr.md
+++ b/docs/getting-started/linux.fr.md
@@ -45,6 +45,16 @@
     !!! note "Fedora 44 KDE Wayland"
         En cas de crash au demarrage (`Could not create default EGL display: EGL_BAD_PARAMETER`), consultez la section Problemes connus ci-dessous.
 
+=== "Paquet Arch (Arch/CachyOS)"
+
+    1. Telechargez `Murmure_amd64.pkg.tar.zst` depuis [GitHub Releases](https://github.com/Kieirra/murmure/releases)
+    2. Installez :
+    ```bash
+    sudo pacman -U Murmure_amd64.pkg.tar.zst
+    ```
+
+    Des paquets maintenus par la communaute (`murmure`, `murmure-bin`) sont aussi disponibles sur l'AUR.
+
 === "AppImage"
 
     1. Telechargez `Murmure_amd64.AppImage` depuis le [site officiel](https://murmure.al1x-ai.com/) (ou [GitHub Releases](https://github.com/Kieirra/murmure/releases))

--- a/docs/getting-started/linux.md
+++ b/docs/getting-started/linux.md
@@ -45,6 +45,16 @@
     !!! note "Fedora 44 KDE Wayland"
         If you encounter a startup crash (`Could not create default EGL display: EGL_BAD_PARAMETER`), see the Known Issues section below.
 
+=== "Arch Package (Arch/CachyOS)"
+
+    1. Download `Murmure_amd64.pkg.tar.zst` from [GitHub Releases](https://github.com/Kieirra/murmure/releases)
+    2. Install:
+    ```bash
+    sudo pacman -U Murmure_amd64.pkg.tar.zst
+    ```
+
+    Community-maintained packages (`murmure`, `murmure-bin`) are also available on the AUR.
+
 === "AppImage"
 
     1. Download `Murmure_amd64.AppImage` from the [official website](https://murmure.al1x-ai.com/) (or [GitHub Releases](https://github.com/Kieirra/murmure/releases))

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,23 @@
+pkgname=murmure
+pkgver=@VERSION@
+pkgrel=1
+pkgdesc="Privacy-first speech-to-text, running entirely on your machine"
+arch=('x86_64')
+url="https://github.com/Kieirra/murmure"
+license=('AGPL-3.0-or-later')
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'hicolor-icon-theme')
+optdepends=('wl-clipboard: Wayland clipboard support'
+            'gtk-layer-shell: Wayland overlay support')
+conflicts=('murmure-bin')
+options=('!strip')
+install=murmure.install
+source=("Murmure_amd64.deb")
+sha256sums=('SKIP')
+
+package() {
+  bsdtar -xOf "${srcdir}/Murmure_amd64.deb" data.tar.gz | bsdtar -xf - -C "${pkgdir}"
+  if [ -f "${pkgdir}/usr/share/applications/murmure.desktop" ]; then
+    mv "${pkgdir}/usr/share/applications/murmure.desktop" "${pkgdir}/usr/share/applications/com.al1x-ai.murmure.desktop"
+  fi
+  install -Dm644 /dev/null "${pkgdir}/usr/lib/murmure/pacman-managed"
+}

--- a/packaging/aur/murmure.install
+++ b/packaging/aur/murmure.install
@@ -1,0 +1,16 @@
+post_install() {
+  if command -v udevadm >/dev/null 2>&1; then
+    udevadm control --reload-rules
+    udevadm trigger --property-match=DEVNAME=/dev/uinput || true
+  fi
+}
+
+post_upgrade() {
+  post_install
+}
+
+post_remove() {
+  if command -v udevadm >/dev/null 2>&1; then
+    udevadm control --reload-rules
+  fi
+}

--- a/src-tauri/src/commands/platform.rs
+++ b/src-tauri/src/commands/platform.rs
@@ -37,6 +37,18 @@ pub fn get_linux_distro_info() -> Option<LinuxDistroInfoDto> {
     })
 }
 
+/// Returns `true` when the app was installed through our pacman package.
+///
+/// Detected via the marker file `/usr/lib/murmure/pacman-managed`, which only
+/// `packaging/aur/PKGBUILD` installs. Consumed by the frontend component
+/// `UpdateChecker` (`src/features/update-checker/update-checker.tsx`), which
+/// links to the GitHub releases page instead of running the in-app updater:
+/// `tauri-plugin-updater` has no pacman installer.
+#[command]
+pub fn is_pacman_managed() -> bool {
+    cfg!(target_os = "linux") && std::path::Path::new("/usr/lib/murmure/pacman-managed").exists()
+}
+
 #[command]
 pub fn get_output_volume_unsupported_reason() -> Option<String> {
     crate::audio::output_volume::unsupported_reason()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -409,6 +409,7 @@ pub fn run() {
             set_show_in_dock,
             get_linux_session_type,
             get_linux_distro_info,
+            is_pacman_managed,
             get_output_volume_unsupported_reason,
             dismiss_wayland_notice,
             dismiss_wayland_clipboard_fallback,

--- a/src/features/update-checker/update-checker.tsx
+++ b/src/features/update-checker/update-checker.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { RefreshCcw, Download } from 'lucide-react';
@@ -14,6 +15,7 @@ export const UpdateChecker = ({ className = '' }: UpdateCheckerProps) => {
     const [isInstalling, setIsInstalling] = useState(false);
     const [downloadProgress, setDownloadProgress] = useState(0);
     const [showUpToDate, setShowUpToDate] = useState(false);
+    const [isPacmanManaged, setIsPacmanManaged] = useState(false);
     const { t } = useTranslation();
 
     const upToDateTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -23,6 +25,11 @@ export const UpdateChecker = ({ className = '' }: UpdateCheckerProps) => {
 
     useEffect(() => {
         checkForUpdates();
+        invoke<boolean>('is_pacman_managed')
+            .then(setIsPacmanManaged)
+            .catch((e) => {
+                console.error('Failed to check pacman install:', e);
+            });
         return () => {
             if (upToDateTimeoutRef.current) clearTimeout(upToDateTimeoutRef.current);
         };
@@ -119,6 +126,20 @@ export const UpdateChecker = ({ className = '' }: UpdateCheckerProps) => {
 
     const isDisabled = isChecking || isInstalling;
     const isClickable = !isDisabled && (updateAvailable || (!isChecking && !showUpToDate));
+
+    if (isPacmanManaged && updateAvailable && !isInstalling) {
+        return (
+            <a
+                href="https://github.com/Kieirra/murmure/releases/latest"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`text-xs transition-colors flex items-center gap-1.5 px-2 py-1 rounded cursor-pointer text-sky-500 hover:text-sky-400 hover:bg-sky-500/10 ${className}`}
+            >
+                <Download className="w-4 h-4" />
+                <span>{t('Update available')}</span>
+            </a>
+        );
+    }
 
     return (
         <button


### PR DESCRIPTION
fix: https://github.com/Kieirra/murmure/issues/358

## Description

The CI reassembles the Debian bundle into a pacman package with `makepkg`, so Arch and CachyOS users get a native install instead of the AppImage, which crashes with `EGL_BAD_PARAMETER` on KDE Wayland. The Tauri updater has no pacman installer, so for those installs only, the update button keeps checking for new versions but opens the releases page instead of downloading.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other:

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [ ] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [ ] I checked for SonarQube issues on the draft PR

The package was built with the exact `docker run` used by the CI, then installed and removed in a clean `archlinux` container. The new CI step itself has not run in a real Actions run yet.
