### PR TITLE
fix(wake-word): résolution du clignotement de l'icône micro sous Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ See [CHANGELOG.md](./CHANGELOG.md).
 - [x] feat(packaging): Add a pacman package for Arch-based distros (CachyOS) to the release, and point the update button to the releases page for those installs, as the Tauri updater has no pacman installer https://github.com/Kieirra/murmure/issues/358#issuecomment-4811232712
 - [x] feat(cli): Add a --hidden flag to launch Murmure without showing the window, combined with control commands such as --transcription or --llm-mode (replaces the internal --autostart workaround)
 - [x] fix(logs): Check the log file size while the app is running and reset it above 1 MB, instead of only checking it at startup, and add an Off level to disable logging completely https://github.com/Kieirra/murmure/issues/417
+- [x] fix(wake-word): Stop the microphone icon from flickering every 10 seconds during silence, the stream watchdog now gets a heartbeat from the audio callback so a silent stream is no longer presumed dead (thank you @nicob3y) https://github.com/Kieirra/murmure/issues/422
 
 ### Backlog
 - [ ] fix(api): Remove the experimental tag and consolidate the API

--- a/src-tauri/src/wake_word/wake_word.rs
+++ b/src-tauri/src/wake_word/wake_word.rs
@@ -24,6 +24,7 @@ const MAX_SEGMENT_OVERLAP_MS: u64 = 1000;
 const PRE_BUFFER_DURATION_MS: f32 = 400.0;
 /// If no audio data is received for this duration, consider the stream dead.
 const STREAM_INACTIVITY_TIMEOUT_S: u64 = 10;
+const HEARTBEAT_INTERVAL_MS: u64 = 2000;
 /// Interval between early partial transcription checks during speech accumulation.
 const EARLY_CHECK_INTERVAL_MS: u64 = 300;
 /// Minimum buffer duration before the first early partial transcription check.
@@ -530,6 +531,7 @@ struct VadState {
     acc_count: usize,
     vad: AdaptiveVad,
     last_check: std::time::Instant,
+    last_heartbeat: std::time::Instant,
     shared_buffer: SharedBuffer,
 }
 
@@ -553,6 +555,7 @@ impl VadState {
             acc_count: 0,
             vad: AdaptiveVad::new(),
             last_check: std::time::Instant::now(),
+            last_heartbeat: std::time::Instant::now(),
             shared_buffer,
         }
     }
@@ -625,22 +628,11 @@ fn process_audio_callback(
     let activity = state.vad.update(rms);
 
     if !state.speech_active {
-        thread_local! {
-            static HEARTBEAT_COUNTER: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+        if state.last_heartbeat.elapsed() >= std::time::Duration::from_millis(HEARTBEAT_INTERVAL_MS)
+        {
+            state.last_heartbeat = std::time::Instant::now();
+            let _ = tx.send(AudioMessage::Heartbeat);
         }
-        HEARTBEAT_COUNTER.with(|counter| {
-            let current = counter.get() + 1;
-
-            let target_duration_ms = (STREAM_INACTIVITY_TIMEOUT_S * 1000) / 5;
-            let ticks_needed = (target_duration_ms / VAD_CHECK_INTERVAL_MS) as usize;
-
-            if current >= ticks_needed {
-                let _ = tx.send(AudioMessage::Heartbeat);
-                counter.set(0);
-            } else {
-                counter.set(current);
-            }
-        });
 
         match activity {
             VoiceActivity::Active => match state.speech_start_time {
@@ -974,6 +966,22 @@ mod tests {
             process_vad_tick(&mut state, 0.013, &tx);
         }
         assert!(state.speech_start_time.is_some());
+    }
+
+    #[test]
+    fn silence_sends_heartbeat_before_the_inactivity_timeout() {
+        let (tx, rx) = mpsc::channel::<AudioMessage>();
+        let mut state = test_vad_state();
+        calibrate_vad(&mut state, 0.0015);
+
+        process_vad_tick(&mut state, 0.0, &tx);
+        assert!(rx.try_recv().is_err());
+
+        state.last_heartbeat =
+            std::time::Instant::now() - std::time::Duration::from_millis(HEARTBEAT_INTERVAL_MS);
+        process_vad_tick(&mut state, 0.0, &tx);
+
+        assert!(matches!(rx.try_recv(), Ok(AudioMessage::Heartbeat)));
     }
 
     #[test]

--- a/src-tauri/src/wake_word/wake_word.rs
+++ b/src-tauri/src/wake_word/wake_word.rs
@@ -33,6 +33,8 @@ const MAX_CONSECUTIVE_FAILURES: u32 = 5;
 /// Backoff bounds applied between restart attempts after a short-lived death.
 const BACKOFF_BASE_MS: u64 = 500;
 const BACKOFF_MAX_MS: u64 = 30_000;
+/// Interval between voice activity detection (VAD) checks.
+const VAD_CHECK_INTERVAL_MS: u64 = 33;
 
 /// Number of samples kept as overlap after a max-duration flush. Clamped so the
 /// retained tail can never be >= the segment itself, which would stall progress.
@@ -315,7 +317,7 @@ fn listener_loop(
     let sample_rate = config.sample_rate() as usize;
     let channels = config.channels() as usize;
 
-    let (tx, rx) = mpsc::channel::<Vec<f32>>();
+    let (tx, rx) = mpsc::channel::<AudioMessage>();
 
     let stop = stop_signal.clone();
 
@@ -402,7 +404,7 @@ fn listener_loop(
 
         // Use a shorter timeout to allow periodic early checks
         match rx.recv_timeout(std::time::Duration::from_millis(50)) {
-            Ok(segment) => {
+            Ok(AudioMessage::Segment(segment)) => {
                 last_audio_time = std::time::Instant::now();
                 // A completed segment arrived (silence cutoff or max duration).
                 // Reset early check state since the segment is done.
@@ -422,6 +424,9 @@ fn listener_loop(
                     );
                     try_handle_wake_word(app, &text, &normalized, entries, "segment");
                 }
+            }
+            Ok(AudioMessage::Heartbeat) => {
+                last_audio_time = std::time::Instant::now();
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 if stream_error.load(Ordering::SeqCst) {
@@ -567,11 +572,20 @@ impl VadState {
     }
 }
 
+/// This enum acts as a watchdog mechanism: the `Heartbeat` variant keeps the
+/// `listener_loop` alive during long periods of silence, preventing inaccurate
+/// stream destructions.
+#[derive(Debug)]
+enum AudioMessage {
+    Segment(Vec<f32>),
+    Heartbeat,
+}
+
 fn process_audio_callback(
     data: &[f32],
     channels: usize,
     state: &mut VadState,
-    tx: &mpsc::Sender<Vec<f32>>,
+    tx: &mpsc::Sender<AudioMessage>,
 ) {
     for frame in data.chunks_exact(channels) {
         let sample = if channels == 1 {
@@ -595,7 +609,7 @@ fn process_audio_callback(
         }
     }
 
-    if state.last_check.elapsed() < std::time::Duration::from_millis(33) {
+    if state.last_check.elapsed() < std::time::Duration::from_millis(VAD_CHECK_INTERVAL_MS) {
         return;
     }
     state.last_check = std::time::Instant::now();
@@ -611,6 +625,23 @@ fn process_audio_callback(
     let activity = state.vad.update(rms);
 
     if !state.speech_active {
+        thread_local! {
+            static HEARTBEAT_COUNTER: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+        }
+        HEARTBEAT_COUNTER.with(|counter| {
+            let current = counter.get() + 1;
+
+            let target_duration_ms = (STREAM_INACTIVITY_TIMEOUT_S * 1000) / 5;
+            let ticks_needed = (target_duration_ms / VAD_CHECK_INTERVAL_MS) as usize;
+
+            if current >= ticks_needed {
+                let _ = tx.send(AudioMessage::Heartbeat);
+                counter.set(0);
+            } else {
+                counter.set(current);
+            }
+        });
+
         match activity {
             VoiceActivity::Active => match state.speech_start_time {
                 Some(start) => {
@@ -653,7 +684,7 @@ fn process_audio_callback(
                         state.sync_shared_buffer();
 
                         if !segment.is_empty() {
-                            let _ = tx.send(segment);
+                            let _ = tx.send(AudioMessage::Segment(segment));
                         }
                     }
                 }
@@ -673,7 +704,7 @@ fn process_audio_callback(
             state.sync_shared_buffer();
 
             if !segment.is_empty() {
-                let _ = tx.send(segment);
+                let _ = tx.send(AudioMessage::Segment(segment));
             }
         }
     }
@@ -848,19 +879,19 @@ mod tests {
         )
     }
 
-    fn process_vad_tick(state: &mut VadState, rms: f32, tx: &mpsc::Sender<Vec<f32>>) {
+    fn process_vad_tick(state: &mut VadState, rms: f32, tx: &mpsc::Sender<AudioMessage>) {
         state.last_check = std::time::Instant::now() - std::time::Duration::from_millis(34);
-        let samples = vec![rms; TEST_SAMPLE_RATE * 33 / 1000];
+        let samples = vec![rms; TEST_SAMPLE_RATE * VAD_CHECK_INTERVAL_MS as usize / 1000];
         process_audio_callback(&samples, 1, state, tx);
     }
 
     fn calibrate_vad(state: &mut VadState, rms: f32) {
-        for _ in 0..1000 / 33 * 2 {
+        for _ in 0..1000 / VAD_CHECK_INTERVAL_MS * 2 {
             state.vad.observe(rms);
         }
     }
 
-    fn start_weak_speech(state: &mut VadState, tx: &mpsc::Sender<Vec<f32>>) {
+    fn start_weak_speech(state: &mut VadState, tx: &mpsc::Sender<AudioMessage>) {
         for _ in 0..3 {
             process_vad_tick(state, 0.013, tx);
         }
@@ -871,9 +902,18 @@ mod tests {
         assert!(state.speech_active);
     }
 
+    fn receive_next_segment(rx: &mpsc::Receiver<AudioMessage>) -> Vec<f32> {
+        loop {
+            match rx.try_recv().expect("completed segment should be sent") {
+                AudioMessage::Segment(seg) => return seg,
+                AudioMessage::Heartbeat => continue,
+            }
+        }
+    }
+
     #[test]
     fn weak_variable_speech_uses_vad_hysteresis_during_start_delay() {
-        let (tx, _rx) = mpsc::channel::<Vec<f32>>();
+        let (tx, _rx) = mpsc::channel::<AudioMessage>();
         let mut state = test_vad_state();
         calibrate_vad(&mut state, 0.0015);
 
@@ -884,7 +924,7 @@ mod tests {
 
     #[test]
     fn silent_candidate_resets_and_rearms_on_new_speech() {
-        let (tx, _rx) = mpsc::channel::<Vec<f32>>();
+        let (tx, _rx) = mpsc::channel::<AudioMessage>();
         let mut state = test_vad_state();
         calibrate_vad(&mut state, 0.0015);
         for _ in 0..3 {
@@ -911,7 +951,7 @@ mod tests {
 
     #[test]
     fn completed_segment_resets_vad_for_next_candidate() {
-        let (tx, rx) = mpsc::channel::<Vec<f32>>();
+        let (tx, rx) = mpsc::channel::<AudioMessage>();
         let mut state = test_vad_state();
         calibrate_vad(&mut state, 0.0015);
         start_weak_speech(&mut state, &tx);
@@ -923,10 +963,7 @@ mod tests {
 
         assert!(!state.speech_active);
         assert!(state.speech_start_time.is_none());
-        assert!(!rx
-            .try_recv()
-            .expect("completed segment should be sent")
-            .is_empty());
+        assert!(!receive_next_segment(&rx).is_empty());
 
         for _ in 0..10 {
             process_vad_tick(&mut state, 0.0045, &tx);


### PR DESCRIPTION
## Description

Envoi d'un signal heartbeat régulier permettant de distinguer un silence d'un flux audio "cassé" devant être redémarré.
À prendre pour ce que ça vaut car je ne pratique pas vraiment le langage Rust.

Fixes #422

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other: <!-- specify -->

## Tested on

- [ ] Windows
- [X] Linux
- [ ] macOS

## Checklist

- [X] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [X] My PR addresses **one single concern**
- [X] I tested my changes manually and they work as expected
- [X] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [x] I checked for SonarQube issues on the draft PR