### PR TITLE
fix(audio): list bluetooth microphones on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ See [CHANGELOG.md](./CHANGELOG.md).
 - [x] feat(packaging): Add a pacman package for Arch-based distros (CachyOS) to the release, and point the update button to the releases page for those installs, as the Tauri updater has no pacman installer https://github.com/Kieirra/murmure/issues/358#issuecomment-4811232712
 - [x] feat(cli): Add a --hidden flag to launch Murmure without showing the window, combined with control commands such as --transcription or --llm-mode (replaces the internal --autostart workaround)
 - [x] fix(logs): Check the log file size while the app is running and reset it above 1 MB, instead of only checking it at startup, and add an Off level to disable logging completely https://github.com/Kieirra/murmure/issues/417
+- [x] fix(audio): List Bluetooth microphones on Linux, the pactl enumeration required `device.class = "sound"` which PipeWire only sets on ALSA sources, so every `bluez_input` source was dropped https://github.com/Kieirra/murmure/issues/421
 
 ### Backlog
 - [ ] fix(api): Remove the experimental tag and consolidate the API

--- a/src-tauri/src/audio/microphone.rs
+++ b/src-tauri/src/audio/microphone.rs
@@ -105,7 +105,7 @@ fn list_sources_pactl() -> Option<Vec<MicInfo>> {
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
-        if device_class != "sound" {
+        if device_class == "monitor" {
             continue;
         }
 


### PR DESCRIPTION
## Description

Bluetooth microphones (`bluez_input.*`) never appeared in the microphone list on Linux because the pactl enumeration required `device.class = "sound"`, a property that only PipeWire's ALSA/udev path sets. The filter now excludes monitor sources instead, so sources without `device.class` (Bluetooth, and virtual microphones such as NoiseTorch or echo-cancel) are listed. Note: this was not tested manually, there is no Bluetooth headset available on the machine used for this change.

Fixes #421

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other: <!-- specify -->

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [x] I checked for SonarQube issues on the draft PR
