### PR TITLE
fix(audio): wait for the output device before starting the capture

### DIFF
--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -21,11 +21,10 @@ use tauri::{AppHandle, Emitter, Manager};
 type WavWriterType = WavWriter<BufWriter<File>>;
 type SharedWriter = Arc<Mutex<Option<WavWriterType>>>;
 
-// The audible part of start_record.mp3 ends at 180 ms, and the sound thread plays its
-// warmup before it. Capture starts after both so the beep is neither picked up by the
-// microphone nor lowered by the output ducking.
-const START_BEEP_DURATION: std::time::Duration =
-    std::time::Duration::from_millis(250).saturating_add(sound::STREAM_WARMUP_DURATION);
+// The audible part of start_record.mp3 ends at 180 ms. Capture starts after it so the beep
+// is neither picked up by the microphone nor lowered by the output ducking. The warmup is
+// not counted in: `wait_until_ready` has already waited for it.
+const START_BEEP_DURATION: std::time::Duration = std::time::Duration::from_millis(250);
 
 // Wrapper to safely store Stream. Stream on macOS doesn't implement Send.
 pub struct SendStream(pub Option<cpal::Stream>);
@@ -141,6 +140,10 @@ impl AudioRecorder {
         if let Some(stream) = &self.stream.0 {
             let settings = crate::settings::load_settings(&self.app_handle);
             if play_sound {
+                if settings.sound_enabled {
+                    // A device slow to open delays the beep, not the capture on top of it.
+                    sound::wait_until_ready(&self.app_handle);
+                }
                 sound::play_sound(&self.app_handle, sound::Sound::StartRecording);
                 if settings.sound_enabled {
                     std::thread::sleep(START_BEEP_DURATION);

--- a/src-tauri/src/audio/sound.rs
+++ b/src-tauri/src/audio/sound.rs
@@ -11,6 +11,8 @@ use tauri::{AppHandle, Manager};
 
 const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 pub const STREAM_WARMUP_DURATION: Duration = Duration::from_millis(100);
+/// Bounded, so a device that never wakes up delays a recording instead of blocking it.
+const READY_MAX_WAIT: Duration = Duration::from_millis(1500);
 
 const MAX_SOUND_GAIN: f32 = 11.0;
 
@@ -40,6 +42,7 @@ impl Sound {
 enum SoundRequest {
     Play(Sound, f32),
     Prewarm,
+    ReportReady(Sender<()>),
 }
 
 pub struct SoundManager {
@@ -109,6 +112,11 @@ pub fn init_sound_system(app: &AppHandle) {
             };
 
             match received {
+                // Answered only after every earlier request: hence a barrier.
+                Ok(SoundRequest::ReportReady(ack)) => {
+                    let _ = ack.send(());
+                    continue;
+                }
                 Ok(request) => {
                     let just_opened = stream_handle.is_none();
                     if just_opened {
@@ -175,6 +183,31 @@ pub fn play_sound(app: &AppHandle, sound: Sound) {
     } else {
         warn!("SoundManager not initialized");
     }
+}
+
+/// Blocks until the sound thread has handled every request queued before this call, so a
+/// preceding [`prewarm`] is known to have opened and warmed up the device. One thread
+/// serves them in order, hence the guarantee. `false` when the bounded wait expired.
+pub fn wait_until_ready(app: &AppHandle) -> bool {
+    let Some(manager) = app.try_state::<SoundManager>() else {
+        return false;
+    };
+    let (ack_tx, ack_rx) = std::sync::mpsc::channel();
+    if manager.tx.send(SoundRequest::ReportReady(ack_tx)).is_err() {
+        return false;
+    }
+    let started = std::time::Instant::now();
+    let ready = ack_rx.recv_timeout(READY_MAX_WAIT).is_ok();
+    let waited = started.elapsed();
+    if ready {
+        info!("Output device ready after {:?}", waited);
+    } else {
+        warn!(
+            "Output device still not ready after {:?}; starting the capture anyway",
+            waited
+        );
+    }
+    ready
 }
 
 /// Opens and warms up the output stream ahead of the next sound.

--- a/src-tauri/src/audio/sound.rs
+++ b/src-tauri/src/audio/sound.rs
@@ -185,6 +185,15 @@ pub fn play_sound(app: &AppHandle, sound: Sound) {
     }
 }
 
+/// Split out of [`wait_until_ready`] so the barrier can be tested without a running app.
+fn request_ready(tx: &Sender<SoundRequest>, max_wait: Duration) -> bool {
+    let (ack_tx, ack_rx) = std::sync::mpsc::channel();
+    if tx.send(SoundRequest::ReportReady(ack_tx)).is_err() {
+        return false;
+    }
+    ack_rx.recv_timeout(max_wait).is_ok()
+}
+
 /// Blocks until the sound thread has handled every request queued before this call, so a
 /// preceding [`prewarm`] is known to have opened and warmed up the device. One thread
 /// serves them in order, hence the guarantee. `false` when the bounded wait expired.
@@ -192,12 +201,8 @@ pub fn wait_until_ready(app: &AppHandle) -> bool {
     let Some(manager) = app.try_state::<SoundManager>() else {
         return false;
     };
-    let (ack_tx, ack_rx) = std::sync::mpsc::channel();
-    if manager.tx.send(SoundRequest::ReportReady(ack_tx)).is_err() {
-        return false;
-    }
     let started = std::time::Instant::now();
-    let ready = ack_rx.recv_timeout(READY_MAX_WAIT).is_ok();
+    let ready = request_ready(&manager.tx, READY_MAX_WAIT);
     let waited = started.elapsed();
     if ready {
         info!("Output device ready after {:?}", waited);
@@ -248,6 +253,55 @@ mod tests {
     #[test]
     fn clamps_above_the_maximum() {
         assert_eq!(gain_from_percent(255), gain_from_percent(100));
+    }
+
+    /// Stands in for the sound thread: serves requests in order, answering the barrier
+    /// and spending `serve_time` on anything else.
+    fn spawn_server(
+        rx: std::sync::mpsc::Receiver<SoundRequest>,
+        serve_time: Duration,
+    ) -> thread::JoinHandle<()> {
+        thread::spawn(move || {
+            while let Ok(request) = rx.recv() {
+                match request {
+                    SoundRequest::ReportReady(ack) => {
+                        let _ = ack.send(());
+                    }
+                    _ => thread::sleep(serve_time),
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn ready_returns_once_the_thread_answers() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let _server = spawn_server(rx, Duration::ZERO);
+        assert!(request_ready(&tx, Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn ready_waits_for_the_requests_queued_before_it() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let _server = spawn_server(rx, Duration::from_millis(80));
+        let started = std::time::Instant::now();
+        tx.send(SoundRequest::Prewarm).unwrap();
+        assert!(request_ready(&tx, Duration::from_secs(5)));
+        assert!(started.elapsed() >= Duration::from_millis(80));
+    }
+
+    #[test]
+    fn ready_gives_up_when_nothing_answers() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let _unserved = rx;
+        assert!(!request_ready(&tx, Duration::from_millis(20)));
+    }
+
+    #[test]
+    fn ready_gives_up_when_the_thread_is_gone() {
+        let (tx, rx) = std::sync::mpsc::channel::<SoundRequest>();
+        drop(rx);
+        assert!(!request_ready(&tx, Duration::from_secs(5)));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Makes the guard added in `438e5cf` — capture starts after the start beep — hold on any hardware, by waiting for the output device to actually be open instead of sleeping a fixed duration.

## Why

`438e5cf` moved the capture start after the beep, so the beep is neither picked up by the microphone nor lowered by the ducking, and guards it with `sleep(START_BEEP_DURATION)`. The intent is right, but `prewarm` only queues the request to open the device and returns at once, so that sleep has to cover an open whose duration nobody knows. Its margin works out as

```
microphone open - output open + 70 ms
```

so it holds only as long as the output device does not open more than 70 ms slower than the microphone. That is a coincidence between two unrelated hardware timings, not a guarantee. On a device slow to open, the beep plays over an already live microphone, and the ducking applied right after `stream.play()` catches the beep mid-playback. Any dictation following enough idle time for the stream to have been released takes that path, so it does not need an unusual setup.

This is the fragility discussed in #368: nothing guarantees a fixed delay is enough to wake every device on every backend, and it is the kind of thing that breaks silently on hardware the reporter is the only one to own.

## What it does

The sound thread serves its requests in order on a single thread, so a request that does nothing but answer acts as a barrier: once it replies, the open and the warm-up are known to be done. The capture start waits for that reply before playing the beep.

- Bounded at 1.5 s, so a device that never wakes up delays a recording instead of blocking the app. On expiry the caller carries on exactly as it does today.
- `START_BEEP_DURATION` drops from 250 ms + warm-up to 250 ms, since the warm-up is no longer something to guess at — the barrier has already waited for it. This is not a smaller margin, it is the end of counting the same 100 ms twice.
- The margin becomes a constant 70 ms whatever the hardware.

## Measured

Logged wait before the beep, on Bluetooth hearing aids over a dozen dictations: 34 µs to 107 ms, against the 250 ms budget. The variance comes from the microphone open running in parallel — when it is the slower of the two, the barrier finds the work already done and costs nothing.

Latency from shortcut to live microphone is unchanged: 310 to 357 ms measured, against 350 ms fixed before.

The logged wait is also useful on its own. It puts a number on how long a device takes to be ready, which is currently invisible in bug reports about swallowed beeps.

## Tests

The send-and-wait half of `wait_until_ready` is split into `request_ready`, which takes the channel rather than the app handle, so the barrier runs under test without a Tauri app or an audio device. Four cases, covering what the capture start relies on:

- it returns once the thread answers;
- it returns only **after** the requests queued before it, which is the barrier property itself;
- it gives up when nothing answers;
- it gives up when the thread is gone.

The ordering case asserts on a lower bound produced by the stand-in server itself rather than on wall-clock timing, so it does not race.

## Not covered

- Only tested on Linux (Ubuntu 24.04, Wayland, PipeWire). The backends where a slow open is most likely, ALSA dmix and CoreAudio, are exactly the ones I cannot test — the change removes the dependency on their timing rather than accommodating it, but I cannot claim a verification there.
- This touches `sound.rs`, as does #433. They are independent; happy to rebase whichever lands second.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other:

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [ ] I checked for SonarQube issues on the draft PR
