### PR TITLE
fix(shortcuts): improve the paste last transcript shortcut on Linux

### DIFF
--- a/src-tauri/src/history/history.rs
+++ b/src-tauri/src/history/history.rs
@@ -118,7 +118,10 @@ pub fn get_last_transcription(app: &AppHandle) -> Result<String> {
             Err(_) => HistoryData::default(),
         }
     };
-    Ok(data.entries.first().unwrap().text.clone())
+    data.entries
+        .first()
+        .map(|entry| entry.text.clone())
+        .ok_or_else(|| anyhow::anyhow!("History is empty"))
 }
 
 /// Updates the most recent history entry text (used to strip wake word after transcription).

--- a/src-tauri/src/shortcuts/cli_dispatch.rs
+++ b/src-tauri/src/shortcuts/cli_dispatch.rs
@@ -5,7 +5,8 @@ use crate::audio::record_audio;
 use crate::audio::types::RecordingMode;
 use crate::cli::types::CliCommand;
 use crate::shortcuts::shortcuts::{
-    ensure_llm_mode_ready, force_cancel_recording, toggle_recording_action,
+    ensure_llm_mode_ready, force_cancel_recording, spawn_paste_last_transcript,
+    toggle_recording_action,
 };
 use crate::shortcuts::types::{recording_state, RecordingSource, ShortcutState};
 
@@ -17,7 +18,7 @@ pub fn dispatch(app: &AppHandle, cmd: &CliCommand) {
     match cmd {
         CliCommand::Transcription => cli_toggle_recording(app, RecordingMode::Standard),
         CliCommand::TranscriptionCommand => cli_toggle_recording(app, RecordingMode::Command),
-        CliCommand::PasteLast => paste_last(app),
+        CliCommand::PasteLast => spawn_paste_last_transcript(app),
         CliCommand::Cancel => cancel(app),
         CliCommand::VoiceMode => {
             let _ = app.emit("voice-mode-toggle-requested", ());
@@ -55,17 +56,6 @@ fn cli_toggle_recording(app: &AppHandle, mode: RecordingMode) {
     toggle_recording_action(app, target, shortcut_state.inner(), move || {
         record_audio(&app_for_fn, mode);
     });
-}
-
-fn paste_last(app: &AppHandle) {
-    match crate::history::get_last_transcription(app) {
-        Ok(transcript) => {
-            let _ = crate::audio::write_last_transcription(app, &transcript);
-        }
-        Err(e) => {
-            warn!("CLI paste-last: no transcript available ({})", e);
-        }
-    }
 }
 
 fn cancel(app: &AppHandle) {

--- a/src-tauri/src/shortcuts/shortcuts.rs
+++ b/src-tauri/src/shortcuts/shortcuts.rs
@@ -1,15 +1,24 @@
 use crate::audio::types::RecordingMode;
+use crate::shortcuts::modifiers::wait_for_modifiers_released;
 use crate::shortcuts::registry::ShortcutRegistryState;
 use crate::shortcuts::types::{
     recording_state, ActivationMode, KeyEventType, RecordingSource, ShortcutAction,
     ShortcutRegistry, ShortcutState,
 };
-use log::{info, warn};
+use log::{debug, info, warn};
 use parking_lot::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
 
 const SHORTCUT_COOLDOWN: Duration = Duration::from_millis(250);
+
+/// Covers what the modifier wait cannot: the binding's own letter may still be
+/// held, and X11 auto-repeat would then turn the injected paste into several.
+/// Also the only margin under Wayland, where the pressed keys are unknown.
+const MODIFIER_RELEASE_DELAY: Duration = Duration::from_millis(50);
+
+static PASTE_LAST_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 fn within_cooldown(last: &Mutex<Instant>) -> bool {
     last.lock().elapsed() < SHORTCUT_COOLDOWN
@@ -84,9 +93,7 @@ pub fn handle_shortcut_event(
         }
         ShortcutAction::PasteLastTranscript => {
             if event_type == KeyEventType::Pressed {
-                if let Ok(transcript) = crate::history::get_last_transcription(app) {
-                    let _ = crate::audio::write_last_transcription(app, &transcript);
-                }
+                spawn_paste_last_transcript(app);
             }
         }
         ShortcutAction::StartRecordingLlmMode(index) => {
@@ -131,6 +138,37 @@ pub fn handle_shortcut_event(
             }
         }
     }
+}
+
+/// Waits for the physical modifiers: synthetic keys merge with the real
+/// keyboard state, so pasting while the binding is still held reaches the
+/// target app as the whole combination. Runs off the shortcut thread because
+/// on X11 that thread also drains the key events the wait relies on.
+pub(crate) fn spawn_paste_last_transcript(app: &AppHandle) {
+    let transcript = match crate::history::get_last_transcription(app) {
+        Ok(transcript) => transcript,
+        Err(e) => {
+            warn!("Paste last transcript: no transcript available ({})", e);
+            return;
+        }
+    };
+
+    // Overlapping pastes would fight over the clipboard snapshot.
+    if PASTE_LAST_ACTIVE
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        debug!("Paste last transcript: already running, request ignored");
+        return;
+    }
+
+    let app = app.clone();
+    std::thread::spawn(move || {
+        wait_for_modifiers_released();
+        std::thread::sleep(MODIFIER_RELEASE_DELAY);
+        let _ = crate::audio::write_last_transcription(&app, &transcript);
+        PASTE_LAST_ACTIVE.store(false, Ordering::SeqCst);
+    });
 }
 
 fn handle_recording_event<F>(


### PR DESCRIPTION
## Description

The *paste last transcription* shortcut can writes the clipboard and injects the paste while the binding is still physically held, so the target application can receives the whole combination instead of the paste shortcut and then nothing is pasted.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other: <!-- specify -->

## Tested on

- [ ] Windows
- [x] Linux
- [ ] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [x] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [x] I checked for SonarQube issues on the draft PR

## Root cause

`PasteLastTranscript` runs inline on the shortcut thread, on `Pressed`. The Linux path sleeps 150 ms and injects `Ctrl+V` through enigo, while the binding can still be held — and XTEST merges synthetic keys with the real keyboard state, so the target application sees the whole combination instead of the paste shortcut.

Failing attempt, X11 / Ubuntu 24.04, binding `Ctrl+Alt+V`, paste method `Ctrl+V`. `send_paste` runs between `Pressed` and `Released`:

```
[18:23:11][DEBUG][shortcuts::platform_linux::x11] Shortcut Pressed: PasteLastTranscript
[18:23:11][DEBUG][clipboard::clipboard] paste_with_delay calling send_paste, method=CtrlV, text_len=99
[18:23:11][DEBUG][clipboard::clipboard] paste_with_delay send_paste returned Ok
[18:23:11][DEBUG][shortcuts::platform_linux::x11] Shortcut Released: PasteLastTranscript
```

Everything succeeds on Murmure's side but nothing is pasted.

Also a quick tap works: 150 ms is enough for a short press to be released before the injection. Holding the binding for ~500 ms fails every time here.

## Changes

- The paste runs on its own thread and waits for the physical modifiers to be released, the way `spawn_transform_selection` already does for the same kind of shortcut-triggered injection.
- A 50 ms delay covers what that wait cannot: it only tracks modifiers, while the binding's own letter may still be held and auto-repeat would turn the injected paste into several.
- A guard drops a second request while one is in flight, since overlapping pastes would fight over the clipboard snapshot and the suspended flag.
- The CLI path had the same flaw and now goes through the same function instead of its own copy.
