### PR TITLE
fix(macos): reopen the main window when the Dock icon is clicked

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -555,6 +555,16 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app_handle, event| {
+            // macOS: closing the window only hides it (see the
+            // CloseRequested handler above). AppKit asks the delegate what
+            // to do when the Dock icon is clicked with no visible window;
+            // without this the click is a no-op and the only way back to
+            // the UI is the tray menu or a full restart.
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen { .. } = event {
+                show_main_window(app_handle);
+            }
+
             // Explicit UI_DEV_DESTROY on exit, otherwise the device
             // lingers under /proc/bus/input/devices until the kernel
             // reaps us.


### PR DESCRIPTION
## Description

Handles `RunEvent::Reopen` on macOS so that clicking the Dock icon shows the main window again after it has been closed. Fixes #436.

## Context

`CloseRequested` calls `prevent_close()` and hides the window, which is the intended behaviour: Murmure keeps running from the menu bar. But with no visible window left, AppKit routes a Dock click to `applicationShouldHandleReopen`, which Tauri surfaces as `RunEvent::Reopen`. The `run()` closure only matched `RunEvent::Exit`, so the event was dropped and the click did nothing at all.

The fix reuses `show_main_window`, the helper the tray menu and the single-instance handler already call, so every path back to the window now behaves the same way. The handler is unconditional rather than gated on `has_visible_windows`: the helper is idempotent, and this also covers the case where the window is minimised rather than hidden.

`RunEvent::Reopen` is macOS only, hence the `cfg`. Nothing changes on Windows or Linux.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other:

## Tested on

- [ ] Windows
- [ ] Linux
- [x] macOS

Tested on macOS 26.5.2 (Apple Silicon), with a local release build of 1.11.3 carrying this change:

- Close the window with the red button, then click the Dock icon: the window comes back and takes focus. Repeated several times.
- Minimise instead of closing, then click the Dock icon: unchanged.
- Menu bar entry "Open Murmure": unchanged.
- Quit and relaunch: unchanged.

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [ ] I ran `cargo clippy` and `cargo fmt` (if Rust changes)
- [ ] I checked for SonarQube issues on the draft PR

Note on the clippy box: I no longer have the Rust toolchain installed locally, so I could not run `cargo clippy` and `cargo fmt` myself and I am relying on the CI job that runs both. Happy to fix anything it flags.