### PR TITLE
fix(overlay): recompute the input region once the enter animation ends

### DIFF
--- a/src/overlay/use-overlay-input-region.ts
+++ b/src/overlay/use-overlay-input-region.ts
@@ -49,10 +49,21 @@ export const useOverlayInputRegion = () => {
         const mutationObserver = new MutationObserver(scheduleCompute);
         mutationObserver.observe(root, { childList: true, subtree: true, attributes: true });
 
+        // `animate-in zoom-in` enters from scale 0, and the MutationObserver
+        // measures the node on the frame it is inserted, so the rect is
+        // captured at almost zero size. A CSS animation raises no further
+        // mutation and the ResizeObserver only watches the root, whose size
+        // never changes, so nothing would ever correct it. Animation events
+        // bubble, so one listener covers every animated descendant.
+        root.addEventListener('animationend', scheduleCompute);
+        root.addEventListener('transitionend', scheduleCompute);
+
         cleanupRef.current = () => {
             if (frame != null) cancelAnimationFrame(frame);
             resizeObserver.disconnect();
             mutationObserver.disconnect();
+            root.removeEventListener('animationend', scheduleCompute);
+            root.removeEventListener('transitionend', scheduleCompute);
         };
     }, []);
 


### PR DESCRIPTION
## Description

Elements entering the overlay with `animate-in zoom-in` have their input-region rect measured at scale 0, which leaves them unreachable: the overlay is click-through outside the registered rects.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement of an existing feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Other:

## Tested on

- [ ] Windows
- [ ] Linux
- [x] macOS

## Checklist

- [x] I have read [CONTRIBUTING.md](/Kieirra/murmure/blob/main/CONTRIBUTING.md) and [GUIDELINES.md](/Kieirra/murmure/blob/main/GUIDELINES.md)
- [x] My PR addresses **one single concern**
- [x] I tested my changes manually and they work as expected
- [ ] I ran `cargo clippy` and `cargo fmt` (if Rust changes) — no Rust changes
- [ ] I checked for SonarQube issues on the draft PR — will do before marking ready

## Details

`useOverlayInputRegion` recomputes on `MutationObserver` (childList, subtree, attributes) and on a `ResizeObserver` watching the root. Neither fires again once a CSS animation starts: an animation raises no mutation, and the root's size never changes. So an element inserted with `animate-in zoom-in` — which enters from `scale(0)` — has its rect captured on the frame it appears, at almost zero size, and nothing corrects it afterwards.

Measured on an overlay panel carrying that animation, cursor held still over a button inside it:

```
during the animation   rects [(422,692,56,10), (476,691,3,3), (424,698,53,3)]   inside=false
after animationend     rects [(30,618,840,158), (846,602,40,40), (54,714,792,46)] inside=true
```

Listening for `animationend` and `transitionend` on the root fixes the whole class rather than one element: both events bubble, so a single pair of listeners covers every animated descendant.

In `main` today this affects the error message span, which carries `animate-in fade-in zoom-in` and `data-interactive`. The consequence there is mild — clicks fall through to the app underneath — but any future interactive element using the same entry animation would be silently unclickable.

I only have a Mac, so I could not tick Windows and Linux. The change is plain DOM API with no platform-specific behaviour.

---

I used Claude Code to help investigate and write this; the instrumentation that produced the measurement above was added on my machine and I removed it before submitting. I understand what the change does and why, and can discuss it.
